### PR TITLE
fix(show): 판매오픈예정 공연 페이징에 지역 검색 필터 추가

### DIFF
--- a/core/core-api/src/main/java/com/ticket/core/api/controller/request/SaleOpeningSoonSearchParam.java
+++ b/core/core-api/src/main/java/com/ticket/core/api/controller/request/SaleOpeningSoonSearchParam.java
@@ -1,5 +1,6 @@
 package com.ticket.core.api.controller.request;
 
+import com.ticket.core.domain.show.Region;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;
@@ -26,6 +27,13 @@ public class SaleOpeningSoonSearchParam {
             requiredMode = NOT_REQUIRED
     )
     private String title;
+
+    @Schema(
+            description = "지역 검색",
+            example = "SEOUL",
+            requiredMode = NOT_REQUIRED
+    )
+    private Region region;
 
     @Schema(
             description = "판매 시작일 필터 (이 날짜 이후)",
@@ -69,6 +77,7 @@ public class SaleOpeningSoonSearchParam {
     public SaleOpeningSoonSearchParam(
             String category,
             String title,
+            Region region,
             LocalDate saleStartDateFrom,
             LocalDate saleStartDateTo,
             LocalDate saleEndDateFrom,
@@ -77,6 +86,7 @@ public class SaleOpeningSoonSearchParam {
     ) {
         this.category = category;
         this.title = title;
+        this.region = region;
         this.saleStartDateFrom = saleStartDateFrom;
         this.saleStartDateTo = saleStartDateTo;
         this.saleEndDateFrom = saleEndDateFrom;
@@ -90,6 +100,10 @@ public class SaleOpeningSoonSearchParam {
 
     public String getTitle() {
         return title;
+    }
+
+    public Region getRegion() {
+        return region;
     }
 
     public LocalDate getSaleStartDateFrom() {

--- a/core/core-api/src/main/java/com/ticket/core/domain/show/ShowQuerydslRepository.java
+++ b/core/core-api/src/main/java/com/ticket/core/domain/show/ShowQuerydslRepository.java
@@ -323,6 +323,7 @@ public class ShowQuerydslRepository {
         // 판매 시작일이 오늘 이후인 것만 (오픈 예정)
         where.and(show.saleStartDate.goe(LocalDate.now()));
         where.and(categoryCodeEq(param.getCategory()));
+        where.and(regionEq(param.getRegion()));
         where.and(titleContains(param.getTitle()));
         where.and(saleStartDateGoe(param.getSaleStartDateFrom()));
         where.and(saleStartDateLoe(param.getSaleStartDateTo()));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 곧 개시 예정인 판매 검색 시 지역 필터링 기능이 추가되었습니다. 사용자는 이제 특정 지역별로 개시 예정 공연을 검색할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->