### PR TITLE
fix(show): 판매오픈예정 공연 페이징에 최신순 정렬 조건 추가

### DIFF
--- a/core/core-api/src/main/java/com/ticket/core/api/controller/docs/ShowControllerDocs.java
+++ b/core/core-api/src/main/java/com/ticket/core/api/controller/docs/ShowControllerDocs.java
@@ -222,7 +222,7 @@ public interface ShowControllerDocs {
     ApiResponse<SliceResponse<ShowOpeningSoonDetailResponse>> getShowsSaleOpeningSoonPage(
             @ParameterObject SaleOpeningSoonSearchParam param,
             @Parameter(description = "한 번에 조회할 개수 (기본값: 16)", example = "16") int size,
-            @Parameter(description = "정렬 기준 [saleStartApproaching(판매시작일순), popular(인기순)]", example = "saleStartApproaching") String sort
+            @Parameter(description = "정렬 기준 [saleStartApproaching(판매시작일순), popular(인기순), latest(최신순)]", example = "saleStartApproaching") String sort
     );
 
     // ========== 검색 API ==========

--- a/core/core-api/src/main/java/com/ticket/core/domain/show/ShowQuerydslRepository.java
+++ b/core/core-api/src/main/java/com/ticket/core/domain/show/ShowQuerydslRepository.java
@@ -344,7 +344,7 @@ public class ShowQuerydslRepository {
 
         // 1차 쿼리: ID 목록 조회
         List<Tuple> rows = queryFactory
-                .select(show.id, show.saleStartDate, show.viewCount)
+                .select(show.id, show.saleStartDate, show.viewCount, show.createdAt)
                 .distinct()
                 .from(show)
                 .join(showGenre).on(showGenre.show.eq(show))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 예정 중인 공연 조회 시 최신순 정렬 옵션이 추가되었습니다.

* **문서화**
  * API 문서에서 정렬 옵션 설명이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->