### PR TITLE
refactor(likes): 내가 찜한 공연 목록 조회 api member로 이동

### DIFF
--- a/core/core-api/src/main/java/com/ticket/core/api/controller/MemberController.java
+++ b/core/core-api/src/main/java/com/ticket/core/api/controller/MemberController.java
@@ -2,17 +2,17 @@ package com.ticket.core.api.controller;
 
 import com.ticket.core.api.controller.docs.MemberControllerDocs;
 import com.ticket.core.api.controller.response.MemberResponse;
+import com.ticket.core.api.controller.response.ShowLikeSummaryResponse;
 import com.ticket.core.domain.member.Member;
 import com.ticket.core.domain.member.MemberPrincipal;
 import com.ticket.core.domain.member.MemberService;
+import com.ticket.core.domain.showlike.usecase.GetMyShowLikesUseCase;
 import com.ticket.core.support.response.ApiResponse;
+import com.ticket.core.support.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController implements MemberControllerDocs {
 
     private final MemberService memberService;
+    private final GetMyShowLikesUseCase getMyShowLikesUseCase;
 
     @Override
     @GetMapping
@@ -35,5 +36,17 @@ public class MemberController implements MemberControllerDocs {
         memberService.withdraw(memberPrincipal.getMemberId());
         SecurityContextHolder.clearContext();
         return ApiResponse.success();
+    }
+
+    @Override
+    @GetMapping("/me/likes")
+    public ApiResponse<SliceResponse<ShowLikeSummaryResponse>> getMyLikes(
+            final MemberPrincipal memberPrincipal,
+            @RequestParam(required = false) final String cursor,
+            @RequestParam(defaultValue = "20") final int size
+    ) {
+        final GetMyShowLikesUseCase.Input input = new GetMyShowLikesUseCase.Input(memberPrincipal.getMemberId(), cursor, size);
+        final GetMyShowLikesUseCase.Output output = getMyShowLikesUseCase.execute(input);
+        return ApiResponse.success(SliceResponse.from(output.shows(), output.nextCursor()));
     }
 }

--- a/core/core-api/src/main/java/com/ticket/core/api/controller/ShowLikeController.java
+++ b/core/core-api/src/main/java/com/ticket/core/api/controller/ShowLikeController.java
@@ -2,16 +2,13 @@ package com.ticket.core.api.controller;
 
 import com.ticket.core.api.controller.docs.ShowLikeControllerDocs;
 import com.ticket.core.api.controller.response.ShowLikeStatusResponse;
-import com.ticket.core.api.controller.response.ShowLikeSummaryResponse;
 import com.ticket.core.domain.member.MemberPrincipal;
 import com.ticket.core.domain.showlike.usecase.AddShowLikeUseCase;
-import com.ticket.core.domain.showlike.usecase.GetMyShowLikesUseCase;
 import com.ticket.core.domain.showlike.usecase.GetShowLikeStatusUseCase;
 import com.ticket.core.domain.showlike.usecase.RemoveShowLikeUseCase;
 import com.ticket.core.support.exception.AuthException;
 import com.ticket.core.support.exception.ErrorType;
 import com.ticket.core.support.response.ApiResponse;
-import com.ticket.core.support.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,7 +20,6 @@ public class ShowLikeController implements ShowLikeControllerDocs {
     private final AddShowLikeUseCase addShowLikeUseCase;
     private final RemoveShowLikeUseCase removeShowLikeUseCase;
     private final GetShowLikeStatusUseCase getShowLikeStatusUseCase;
-    private final GetMyShowLikesUseCase getMyShowLikesUseCase;
 
     @Override
     @PostMapping("/shows/{showId}")
@@ -59,19 +55,6 @@ public class ShowLikeController implements ShowLikeControllerDocs {
         final GetShowLikeStatusUseCase.Input input = new GetShowLikeStatusUseCase.Input(memberId, showId);
         final GetShowLikeStatusUseCase.Output output = getShowLikeStatusUseCase.execute(input);
         return ApiResponse.success(output.response());
-    }
-
-    @Override
-    @GetMapping("/shows/me")
-    public ApiResponse<SliceResponse<ShowLikeSummaryResponse>> getMyLikes(
-            final MemberPrincipal memberPrincipal,
-            @RequestParam(required = false) final String cursor,
-            @RequestParam(defaultValue = "20") final int size
-    ) {
-        final Long memberId = requireMemberId(memberPrincipal);
-        final GetMyShowLikesUseCase.Input input = new GetMyShowLikesUseCase.Input(memberId, cursor, size);
-        final GetMyShowLikesUseCase.Output output = getMyShowLikesUseCase.execute(input);
-        return ApiResponse.success(SliceResponse.from(output.shows(), output.nextCursor()));
     }
 
     private Long requireMemberId(final MemberPrincipal memberPrincipal) {

--- a/core/core-api/src/main/java/com/ticket/core/api/controller/docs/MemberControllerDocs.java
+++ b/core/core-api/src/main/java/com/ticket/core/api/controller/docs/MemberControllerDocs.java
@@ -1,14 +1,16 @@
 package com.ticket.core.api.controller.docs;
 
 import com.ticket.core.api.controller.response.MemberResponse;
+import com.ticket.core.api.controller.response.ShowLikeSummaryResponse;
 import com.ticket.core.domain.member.MemberPrincipal;
 import com.ticket.core.support.response.ApiResponse;
+import com.ticket.core.support.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "회원(Member)", description = "회원 정보 조회 API")
+@Tag(name = "회원(Member)", description = "회원 정보 및 내 활동 조회 API")
 public interface MemberControllerDocs {
 
     @Operation(summary = "현재 회원 조회", description = "로그인한 회원의 정보를 조회합니다")
@@ -27,5 +29,19 @@ public interface MemberControllerDocs {
     })
     ApiResponse<Void> withdrawCurrentMember(
             @Parameter(hidden = true) MemberPrincipal memberPrincipal
+    );
+
+    @Operation(
+            summary = "내 찜 목록 조회",
+            description = "로그인한 회원의 찜 목록을 커서 기반 페이지네이션으로 조회합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    ApiResponse<SliceResponse<ShowLikeSummaryResponse>> getMyLikes(
+            @Parameter(hidden = true) MemberPrincipal memberPrincipal,
+            @Parameter(description = "커서(마지막 찜 ID)", example = "123") String cursor,
+            @Parameter(description = "페이지 크기", example = "20") int size
     );
 }

--- a/core/core-api/src/main/java/com/ticket/core/api/controller/docs/ShowLikeControllerDocs.java
+++ b/core/core-api/src/main/java/com/ticket/core/api/controller/docs/ShowLikeControllerDocs.java
@@ -1,10 +1,8 @@
 package com.ticket.core.api.controller.docs;
 
 import com.ticket.core.api.controller.response.ShowLikeStatusResponse;
-import com.ticket.core.api.controller.response.ShowLikeSummaryResponse;
 import com.ticket.core.domain.member.MemberPrincipal;
 import com.ticket.core.support.response.ApiResponse;
-import com.ticket.core.support.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -55,17 +53,4 @@ public interface ShowLikeControllerDocs {
             @Parameter(description = "공연 ID", example = "1", required = true) Long showId
     );
 
-    @Operation(
-            summary = "내 찜 목록 조회",
-            description = "인증된 회원의 찜 목록을 커서 기반 페이지네이션으로 조회합니다."
-    )
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
-    })
-    ApiResponse<SliceResponse<ShowLikeSummaryResponse>> getMyLikes(
-            @Parameter(hidden = true) MemberPrincipal memberPrincipal,
-            @Parameter(description = "커서(마지막 찜 ID)", example = "123") String cursor,
-            @Parameter(description = "페이지 크기", example = "20") int size
-    );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 현재 사용자의 좋아요한 공연 목록을 조회하는 기능 추가 (페이지네이션 지원)

* **문서**
  * API 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->