### PR TITLE
fix: 유스케이스 Output 변경에 맞춰 테스트 정리

### DIFF
--- a/core/core-api/src/test/java/com/ticket/core/domain/auth/usecase/ExchangeOAuth2TokenUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/auth/usecase/ExchangeOAuth2TokenUseCaseTest.java
@@ -54,7 +54,10 @@ class ExchangeOAuth2TokenUseCaseTest {
                 useCase.execute(new ExchangeOAuth2TokenUseCase.Input("oauth-code"), servletResponse);
 
         //then
-        assertThat(output.authLoginResponse()).isEqualTo(response);
+        assertThat(output.accessToken()).isEqualTo(response.accessToken());
+        assertThat(output.tokenType()).isEqualTo(response.tokenType());
+        assertThat(output.expiresIn()).isEqualTo(response.expiresIn());
+        assertThat(output.memberId()).isEqualTo(response.memberId());
         verify(oAuth2AuthCodeService).consumeCode("oauth-code");
         verify(memberFinder).findActiveMemberById(7L);
         verify(authTokenApplicationService).issueTokens(member, servletResponse);

--- a/core/core-api/src/test/java/com/ticket/core/domain/auth/usecase/LoginUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/auth/usecase/LoginUseCaseTest.java
@@ -43,7 +43,10 @@ class LoginUseCaseTest {
         LoginUseCase.Output output = useCase.execute(new LoginUseCase.Input("user@example.com", "password"), servletResponse);
 
         //then
-        assertThat(output.authLoginResponse()).isEqualTo(response);
+        assertThat(output.accessToken()).isEqualTo(response.accessToken());
+        assertThat(output.tokenType()).isEqualTo(response.tokenType());
+        assertThat(output.expiresIn()).isEqualTo(response.expiresIn());
+        assertThat(output.memberId()).isEqualTo(response.memberId());
         verify(authService).login("user@example.com", "password");
         verify(authTokenApplicationService).issueTokens(member, servletResponse);
     }

--- a/core/core-api/src/test/java/com/ticket/core/domain/auth/usecase/RefreshAuthTokenUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/auth/usecase/RefreshAuthTokenUseCaseTest.java
@@ -54,7 +54,10 @@ class RefreshAuthTokenUseCaseTest {
                 useCase.execute(new RefreshAuthTokenUseCase.Input("refresh-token"), servletResponse);
 
         //then
-        assertThat(output.authLoginResponse()).isEqualTo(response);
+        assertThat(output.accessToken()).isEqualTo(response.accessToken());
+        assertThat(output.tokenType()).isEqualTo(response.tokenType());
+        assertThat(output.expiresIn()).isEqualTo(response.expiresIn());
+        assertThat(output.memberId()).isEqualTo(response.memberId());
         verify(refreshTokenService).validate("refresh-token");
         verify(memberFinder).findActiveMemberById(3L);
         verify(authTokenApplicationService).rotateTokens(member, "refresh-token", servletResponse);

--- a/core/core-api/src/test/java/com/ticket/core/domain/order/command/usecase/TerminateOrderUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/order/command/usecase/TerminateOrderUseCaseTest.java
@@ -53,18 +53,16 @@ class TerminateOrderUseCaseTest {
     void 취소시_주문상태를_전이하고_이벤트를_발행한다() {
         //given
         Order order = createOrder(10L, 100L, "hold-key");
-        LocalDateTime now = LocalDateTime.of(2026, 3, 15, 10, 0);
-
         when(orderFinder.findPendingOwnedByOrderKeyForUpdate("order-key", 1L)).thenReturn(order);
-        when(orderTerminationDomainService.cancel(order, now))
+        when(orderTerminationDomainService.cancel(org.mockito.Mockito.eq(order), org.mockito.ArgumentMatchers.any(LocalDateTime.class)))
                 .thenReturn(new OrderTerminationDomainService.OrderTerminationResult(100L, "hold-key", List.of(42L)));
 
         //when
-        useCase.cancel("order-key", 1L, now);
+        useCase.cancel(new TerminateOrderUseCase.Input("order-key", 1L));
 
         //then
         verify(memberFinder).findActiveMemberById(1L);
-        verify(orderTerminationDomainService).cancel(order, now);
+        verify(orderTerminationDomainService).cancel(org.mockito.Mockito.eq(order), org.mockito.ArgumentMatchers.any(LocalDateTime.class));
         ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
         verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
         assertThat(eventCaptor.getValue().toString()).contains("hold-key").contains("42");

--- a/core/core-api/src/test/java/com/ticket/core/domain/order/query/usecase/GetOrderDetailUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/order/query/usecase/GetOrderDetailUseCaseTest.java
@@ -1,6 +1,5 @@
 package com.ticket.core.domain.order.query.usecase;
 
-import com.ticket.core.api.controller.response.OrderDetailResponse;
 import com.ticket.core.domain.member.Member;
 import com.ticket.core.domain.member.MemberFinder;
 import com.ticket.core.domain.member.vo.Email;
@@ -82,14 +81,12 @@ class GetOrderDetailUseCaseTest {
 
         GetOrderDetailUseCase.Output output = useCase.execute(new GetOrderDetailUseCase.Input("order-key", 1L));
 
-        //when
-        OrderDetailResponse response = output.order();
         //then
-        assertThat(response.orderKey()).isEqualTo("order-key");
-        assertThat(response.show().title()).isEqualTo("뮤지컬");
-        assertThat(response.performance().venueName()).isEqualTo("올림픽홀");
-        assertThat(response.booker().email()).isEqualTo("user@example.com");
-        assertThat(response.tickets().count()).isEqualTo(1);
+        assertThat(output.orderKey()).isEqualTo("order-key");
+        assertThat(output.show().title()).isEqualTo("뮤지컬");
+        assertThat(output.performance().venueName()).isEqualTo("올림픽홀");
+        assertThat(output.booker().email()).isEqualTo("user@example.com");
+        assertThat(output.tickets().count()).isEqualTo(1);
     }
 
     private Venue createVenue(final String name) throws Exception {
@@ -127,4 +124,3 @@ class GetOrderDetailUseCaseTest {
         return performance;
     }
 }
-

--- a/core/core-api/src/test/java/com/ticket/core/domain/performance/usecase/GetPerformanceScheduleListUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/performance/usecase/GetPerformanceScheduleListUseCaseTest.java
@@ -57,9 +57,9 @@ class GetPerformanceScheduleListUseCaseTest {
         GetPerformanceScheduleListUseCase.Output output = useCase.execute(new GetPerformanceScheduleListUseCase.Input(10L));
 
         //then
-        assertThat(output.schedules().showId()).isEqualTo(100L);
-        assertThat(output.schedules().selectedPerformanceId()).isEqualTo(10L);
-        assertThat(output.schedules().schedules()).hasSize(2);
+        assertThat(output.showId()).isEqualTo(100L);
+        assertThat(output.selectedPerformanceId()).isEqualTo(10L);
+        assertThat(output.schedules()).hasSize(2);
     }
 
     @Test
@@ -91,9 +91,8 @@ class GetPerformanceScheduleListUseCaseTest {
         GetPerformanceScheduleListUseCase.Output output = useCase.execute(new GetPerformanceScheduleListUseCase.Input(10L));
 
         //then
-        assertThat(output.schedules().showId()).isEqualTo(100L);
-        assertThat(output.schedules().selectedPerformanceId()).isEqualTo(10L);
-        assertThat(output.schedules().schedules()).isEmpty();
+        assertThat(output.showId()).isEqualTo(100L);
+        assertThat(output.selectedPerformanceId()).isEqualTo(10L);
+        assertThat(output.schedules()).isEmpty();
     }
 }
-

--- a/core/core-api/src/test/java/com/ticket/core/domain/performance/usecase/GetPerformanceSummaryUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/performance/usecase/GetPerformanceSummaryUseCaseTest.java
@@ -49,9 +49,9 @@ class GetPerformanceSummaryUseCaseTest {
         GetPerformanceSummaryUseCase.Output output = useCase.execute(new GetPerformanceSummaryUseCase.Input(1L));
 
         //then
-        assertThat(output.summary().title()).isEqualTo("싱어게인");
-        assertThat(output.summary().region()).isEqualTo("충청");
-        assertThat(output.summary().startTime()).isEqualTo(startTime);
+        assertThat(output.title()).isEqualTo("싱어게인");
+        assertThat(output.region()).isEqualTo("충청");
+        assertThat(output.startTime()).isEqualTo(startTime);
     }
 
     @Test
@@ -85,9 +85,8 @@ class GetPerformanceSummaryUseCaseTest {
         GetPerformanceSummaryUseCase.Output output = useCase.execute(new GetPerformanceSummaryUseCase.Input(1L));
 
         //then
-        assertThat(output.summary().title()).isEqualTo("싱어게인");
-        assertThat(output.summary().region()).isNull();
-        assertThat(output.summary().startTime()).isEqualTo(startTime);
+        assertThat(output.title()).isEqualTo("싱어게인");
+        assertThat(output.region()).isNull();
+        assertThat(output.startTime()).isEqualTo(startTime);
     }
 }
-

--- a/core/core-api/src/test/java/com/ticket/core/domain/performanceseat/query/usecase/GetSeatAvailabilityUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/performanceseat/query/usecase/GetSeatAvailabilityUseCaseTest.java
@@ -66,7 +66,7 @@ class GetSeatAvailabilityUseCaseTest {
         GetSeatAvailabilityUseCase.Output output = useCase.execute(new GetSeatAvailabilityUseCase.Input(10L));
 
         //then
-        assertThat(output.availability()).isEqualTo(response);
+        assertThat(output.grades()).isEqualTo(response.grades());
         verify(seatAvailabilityCalculator).calculate(rows, Set.of(1L, 2L));
     }
 

--- a/core/core-api/src/test/java/com/ticket/core/domain/performanceseat/query/usecase/GetSeatStatusUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/performanceseat/query/usecase/GetSeatStatusUseCaseTest.java
@@ -54,7 +54,7 @@ class GetSeatStatusUseCaseTest {
         GetSeatStatusUseCase.Output output = useCase.execute(new GetSeatStatusUseCase.Input(10L));
 
         //then
-        assertThat(output.status().seats()).containsExactly(
+        assertThat(output.seats()).containsExactly(
                 new SeatStatusResponse.SeatState(1L, SeatStatus.OCCUPIED),
                 new SeatStatusResponse.SeatState(2L, SeatStatus.OCCUPIED)
         );
@@ -78,8 +78,7 @@ class GetSeatStatusUseCaseTest {
         GetSeatStatusUseCase.Output output = useCase.execute(new GetSeatStatusUseCase.Input(10L));
 
         //then
-        assertThat(output.status().seats()).containsExactlyElementsOf(dbStates);
+        assertThat(output.seats()).containsExactlyElementsOf(dbStates);
         verify(seatMapQueryRepository).findSeatStatuses(10L);
     }
 }
-

--- a/core/core-api/src/test/java/com/ticket/core/domain/performanceseat/query/usecase/GetVenueLayoutUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/performanceseat/query/usecase/GetVenueLayoutUseCaseTest.java
@@ -42,8 +42,8 @@ class GetVenueLayoutUseCaseTest {
         GetVenueLayoutUseCase.Output output = useCase.execute(new GetVenueLayoutUseCase.Input(100L));
 
         //then
-        assertThat(output.layout().name()).isEqualTo("올림픽홀");
-        assertThat(output.layout().viewBoxWidth()).isEqualTo(1000);
+        assertThat(output.name()).isEqualTo("올림픽홀");
+        assertThat(output.viewBoxWidth()).isEqualTo(1000);
     }
 
     @Test
@@ -60,4 +60,3 @@ class GetVenueLayoutUseCaseTest {
                 .satisfies(exception -> assertThat(((CoreException) exception).getErrorType()).isEqualTo(ErrorType.NOT_FOUND_DATA));
     }
 }
-

--- a/core/core-api/src/test/java/com/ticket/core/domain/queue/usecase/GetQueueStatusUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/queue/usecase/GetQueueStatusUseCaseTest.java
@@ -1,11 +1,8 @@
 package com.ticket.core.domain.queue.usecase;
 
 import com.ticket.core.domain.queue.model.QueueEntryStatus;
-import com.ticket.core.domain.queue.model.QueueLevel;
 import com.ticket.core.domain.queue.runtime.QueueEntryRuntime;
 import com.ticket.core.domain.queue.runtime.QueueRuntimeStore;
-import com.ticket.core.domain.queue.support.QueuePolicyResolver;
-import com.ticket.core.domain.queue.support.ResolvedQueuePolicy;
 import com.ticket.core.support.exception.AuthException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,7 +10,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -26,9 +22,6 @@ import static org.mockito.Mockito.when;
 class GetQueueStatusUseCaseTest {
 
     @Mock
-    private QueuePolicyResolver queuePolicyResolver;
-
-    @Mock
     private QueueRuntimeStore queueRuntimeStore;
 
     @InjectMocks
@@ -37,7 +30,6 @@ class GetQueueStatusUseCaseTest {
     @Test
     void 엔트리가_없으면_EXPIRED를_반환한다() {
         //given
-        when(queuePolicyResolver.resolve(10L)).thenReturn(createPolicy());
         when(queueRuntimeStore.findEntry("qe-10")).thenReturn(Optional.empty());
 
         //when
@@ -52,7 +44,6 @@ class GetQueueStatusUseCaseTest {
     void 대기중_엔트리는_현재_순번과_예상대기시간을_반환한다() {
         //given
         QueueEntryRuntime waiting = new QueueEntryRuntime(10L, 100L, "qe-10", QueueEntryStatus.WAITING, 5L, null, null);
-        when(queuePolicyResolver.resolve(10L)).thenReturn(createPolicy());
         when(queueRuntimeStore.findEntry("qe-10")).thenReturn(Optional.of(waiting));
         when(queueRuntimeStore.findWaitingPosition(10L, "qe-10")).thenReturn(Optional.of(5L));
 
@@ -68,7 +59,6 @@ class GetQueueStatusUseCaseTest {
     void 대기순번을_찾지_못하면_0초기값으로_계산한다() {
         //given
         QueueEntryRuntime waiting = new QueueEntryRuntime(10L, 100L, "qe-10", QueueEntryStatus.WAITING, 5L, null, null);
-        when(queuePolicyResolver.resolve(10L)).thenReturn(createPolicy());
         when(queueRuntimeStore.findEntry("qe-10")).thenReturn(Optional.of(waiting));
         when(queueRuntimeStore.findWaitingPosition(10L, "qe-10")).thenReturn(Optional.empty());
 
@@ -91,7 +81,6 @@ class GetQueueStatusUseCaseTest {
                 "qt-11",
                 LocalDateTime.of(2026, 3, 15, 20, 20)
         );
-        when(queuePolicyResolver.resolve(10L)).thenReturn(createPolicy());
         when(queueRuntimeStore.findEntry("qe-11")).thenReturn(Optional.of(admitted));
         when(queueRuntimeStore.isValidToken(10L, "qt-11")).thenReturn(false);
 
@@ -115,7 +104,6 @@ class GetQueueStatusUseCaseTest {
                 "qt-11",
                 LocalDateTime.of(2026, 3, 15, 20, 20)
         );
-        when(queuePolicyResolver.resolve(10L)).thenReturn(createPolicy());
         when(queueRuntimeStore.findEntry("qe-11")).thenReturn(Optional.of(admitted));
         when(queueRuntimeStore.isValidToken(10L, "qt-11")).thenReturn(true);
 
@@ -132,7 +120,6 @@ class GetQueueStatusUseCaseTest {
     void LEFT_상태_엔트리는_그대로_반환한다() {
         //given
         QueueEntryRuntime left = new QueueEntryRuntime(10L, 100L, "qe-12", QueueEntryStatus.LEFT, 1L, null, null);
-        when(queuePolicyResolver.resolve(10L)).thenReturn(createPolicy());
         when(queueRuntimeStore.findEntry("qe-12")).thenReturn(Optional.of(left));
 
         //when
@@ -146,7 +133,6 @@ class GetQueueStatusUseCaseTest {
     void 다른_회원의_엔트리를_조회하면_예외가_발생한다() {
         //given
         QueueEntryRuntime waiting = new QueueEntryRuntime(10L, 999L, "qe-10", QueueEntryStatus.WAITING, 5L, null, null);
-        when(queuePolicyResolver.resolve(10L)).thenReturn(createPolicy());
         when(queueRuntimeStore.findEntry("qe-10")).thenReturn(Optional.of(waiting));
 
         //when //then
@@ -154,14 +140,5 @@ class GetQueueStatusUseCaseTest {
                 .isInstanceOf(AuthException.class);
     }
 
-    private ResolvedQueuePolicy createPolicy() {
-        return new ResolvedQueuePolicy(
-                true,
-                QueueLevel.LEVEL_1,
-                300,
-                Duration.ofMinutes(10),
-                Duration.ofHours(1)
-        );
-    }
 }
 

--- a/core/core-api/src/test/java/com/ticket/core/domain/show/query/usecase/CountSearchShowsUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/show/query/usecase/CountSearchShowsUseCaseTest.java
@@ -32,7 +32,7 @@ class CountSearchShowsUseCaseTest {
         CountSearchShowsUseCase.Output output = useCase.execute(new CountSearchShowsUseCase.Input(request));
 
         //then
-        assertThat(output.response().count()).isEqualTo(42L);
+        assertThat(output.count()).isEqualTo(42L);
         verify(showListQueryRepository).countSearchShows(request);
     }
 
@@ -46,8 +46,7 @@ class CountSearchShowsUseCaseTest {
         CountSearchShowsUseCase.Output output = useCase.execute(new CountSearchShowsUseCase.Input(request));
 
         //then
-        assertThat(output.response().count()).isZero();
+        assertThat(output.count()).isZero();
         verify(showListQueryRepository).countSearchShows(request);
     }
 }
-

--- a/core/core-api/src/test/java/com/ticket/core/domain/showlike/usecase/AddShowLikeUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/showlike/usecase/AddShowLikeUseCaseTest.java
@@ -50,8 +50,8 @@ class AddShowLikeUseCaseTest {
         AddShowLikeUseCase.Output output = useCase.execute(new AddShowLikeUseCase.Input(1L, 2L));
 
         //then
-        assertThat(output.response().liked()).isTrue();
-        assertThat(output.response().likeCount()).isEqualTo(5L);
+        assertThat(output.liked()).isTrue();
+        assertThat(output.likeCount()).isEqualTo(5L);
     }
 
     @Test
@@ -66,7 +66,7 @@ class AddShowLikeUseCaseTest {
         AddShowLikeUseCase.Output output = useCase.execute(new AddShowLikeUseCase.Input(1L, 2L));
 
         //then
-        assertThat(output.response().liked()).isTrue();
+        assertThat(output.liked()).isTrue();
         verify(showLikeRepository).save(any());
     }
 
@@ -106,4 +106,3 @@ class AddShowLikeUseCaseTest {
         );
     }
 }
-

--- a/core/core-api/src/test/java/com/ticket/core/domain/showlike/usecase/GetShowLikeStatusUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/showlike/usecase/GetShowLikeStatusUseCaseTest.java
@@ -49,8 +49,8 @@ class GetShowLikeStatusUseCaseTest {
         GetShowLikeStatusUseCase.Output output = useCase.execute(new GetShowLikeStatusUseCase.Input(1L, 2L));
 
         //then
-        assertThat(output.response().liked()).isTrue();
-        assertThat(output.response().likeCount()).isEqualTo(7L);
+        assertThat(output.liked()).isTrue();
+        assertThat(output.likeCount()).isEqualTo(7L);
         verify(showFinder).validateShowExists(2L);
     }
 
@@ -74,4 +74,3 @@ class GetShowLikeStatusUseCaseTest {
         );
     }
 }
-

--- a/core/core-api/src/test/java/com/ticket/core/domain/showlike/usecase/RemoveShowLikeUseCaseTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/showlike/usecase/RemoveShowLikeUseCaseTest.java
@@ -50,8 +50,8 @@ class RemoveShowLikeUseCaseTest {
         RemoveShowLikeUseCase.Output output = useCase.execute(new RemoveShowLikeUseCase.Input(1L, 2L));
 
         //then
-        assertThat(output.response().liked()).isFalse();
-        assertThat(output.response().likeCount()).isEqualTo(4L);
+        assertThat(output.liked()).isFalse();
+        assertThat(output.likeCount()).isEqualTo(4L);
         verify(showLikeRepository).delete(showLike);
     }
 
@@ -65,8 +65,8 @@ class RemoveShowLikeUseCaseTest {
         RemoveShowLikeUseCase.Output output = useCase.execute(new RemoveShowLikeUseCase.Input(1L, 2L));
 
         //then
-        assertThat(output.response().liked()).isFalse();
-        assertThat(output.response().likeCount()).isZero();
+        assertThat(output.liked()).isFalse();
+        assertThat(output.likeCount()).isZero();
         verify(showLikeRepository, never()).delete(any());
     }
 
@@ -90,4 +90,3 @@ class RemoveShowLikeUseCaseTest {
         );
     }
 }
-


### PR DESCRIPTION
## Summary
- 유스케이스 Output record 평탄화에 맞춰 관련 테스트 접근자를 현재 계약으로 정리했습니다.
- TerminateOrderUseCase와 GetQueueStatusUseCase의 변경된 시그니처 및 의존성 제거를 테스트에 반영했습니다.
- 불필요한 queue policy mock/stub을 제거해 Mockito strict stubbing 실패를 없앴습니다.

## Test Plan
- [x] ./gradlew test
- [x] ./gradlew :core:core-api:test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 내부 API 구조를 간소화하여 접근 패턴을 단순화했습니다.
  * 중첩된 객체 래퍼를 제거하고 직접 접근자를 노출하도록 개선했습니다.
  * 테스트 커버리지를 강화하여 코드 안정성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->