### PR TITLE
fix(image): 상세 조회 리사이징 적용

### DIFF
--- a/core/core-api/src/main/java/com/ticket/core/domain/show/query/ShowDetailQueryRepository.java
+++ b/core/core-api/src/main/java/com/ticket/core/domain/show/query/ShowDetailQueryRepository.java
@@ -8,10 +8,12 @@ import com.ticket.core.api.controller.response.ShowDetailResponse.PerformanceInf
 import com.ticket.core.api.controller.response.ShowDetailResponse.PerformerInfo;
 import com.ticket.core.domain.performance.Performance;
 import com.ticket.core.domain.show.Show;
+import com.ticket.core.domain.show.image.ShowImagePathResolver;
 import com.ticket.core.domain.show.mapping.ShowGrade;
 import com.ticket.core.domain.show.performer.Performer;
 import com.ticket.core.domain.show.venue.Venue;
 import com.ticket.core.enums.BookingStatus;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -29,13 +31,11 @@ import static com.ticket.core.domain.show.QShow.show;
 import static com.ticket.core.domain.showlike.QShowLike.showLike;
 
 @Repository
+@RequiredArgsConstructor
 public class ShowDetailQueryRepository {
 
     private final JPAQueryFactory queryFactory;
-
-    public ShowDetailQueryRepository(final JPAQueryFactory queryFactory) {
-        this.queryFactory = queryFactory;
-    }
+    private final ShowImagePathResolver showImagePathResolver;
 
     public Optional<ShowDetailResponse> findShowDetail(final Long showId) {
         final Show showEntity = fetchShow(showId);
@@ -157,7 +157,7 @@ public class ShowDetailQueryRepository {
                 showEntity.getSaleType(),
                 showEntity.getSaleStartDate(),
                 showEntity.getSaleEndDate(),
-                showEntity.getImage(),
+                showImagePathResolver.toCardImage(showEntity.getImage()),
                 toVenueInfo(showEntity.getVenue()),
                 toPerformerInfo(showEntity.getPerformer()),
                 genreNames,

--- a/core/core-api/src/test/java/com/ticket/core/domain/show/query/ShowDetailQueryRepositoryTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/show/query/ShowDetailQueryRepositoryTest.java
@@ -4,6 +4,7 @@ import com.ticket.core.api.controller.response.ShowDetailResponse;
 import com.ticket.core.domain.show.Show;
 import com.ticket.core.domain.show.category.Category;
 import com.ticket.core.domain.show.genre.Genre;
+import com.ticket.core.domain.show.image.ShowImagePathResolver;
 import com.ticket.core.domain.show.meta.Region;
 import com.ticket.core.domain.show.performer.Performer;
 import com.ticket.core.domain.show.venue.Venue;
@@ -20,7 +21,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Import(ShowDetailQueryRepository.class)
+@Import({ShowDetailQueryRepository.class, ShowImagePathResolver.class})
 @SuppressWarnings("NonAsciiCharacters")
 class ShowDetailQueryRepositoryTest extends QueryRepositoryTestSupport {
 
@@ -37,6 +38,10 @@ class ShowDetailQueryRepositoryTest extends QueryRepositoryTestSupport {
         Genre genre = persistGenre("KPOP", "케이팝", category);
         Show show = persistShow("대표 공연", venue, performer, 321L, LocalDateTime.now().minusDays(2), LocalDateTime.now().plusDays(10));
         showId = show.getId();
+        entityManager.createNativeQuery("update shows set image = :image where id = :id")
+                .setParameter("image", "/api/images/shows/" + showId + ".png")
+                .setParameter("id", showId)
+                .executeUpdate();
         persistShowGenre(show, genre);
         persistShowGrade(show, "VIP", "VIP석", BigDecimal.valueOf(150000), 1);
         persistShowGrade(show, "R", "R석", BigDecimal.valueOf(100000), 2);
@@ -62,6 +67,7 @@ class ShowDetailQueryRepositoryTest extends QueryRepositoryTestSupport {
         assertThat(detail.grades()).extracting("gradeCode").containsExactly("VIP", "R");
         assertThat(detail.performanceDates()).hasSize(1);
         assertThat(detail.performanceDates().getFirst().performances()).hasSize(2);
+        assertThat(detail.image()).isEqualTo("/api/images/shows/card/" + showId + ".jpg");
         assertThat(detail.venue().name()).isEqualTo("예술의전당");
         assertThat(detail.performer().name()).isEqualTo("홍길동");
     }

--- a/core/core-api/src/test/java/com/ticket/core/domain/show/query/ShowListQueryRepositoryTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/domain/show/query/ShowListQueryRepositoryTest.java
@@ -6,6 +6,7 @@ import com.ticket.core.config.QuerydslConfig;
 import com.ticket.core.api.controller.response.ShowResponse;
 import com.ticket.core.api.controller.response.ShowSearchResponse;
 import com.ticket.core.domain.show.Show;
+import com.ticket.core.domain.show.image.ShowImagePathResolver;
 import com.ticket.core.domain.show.meta.Region;
 import com.ticket.core.domain.show.meta.SaleType;
 import com.ticket.core.domain.show.query.model.ShowParam;
@@ -59,6 +60,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         QuerydslConfig.class,
         ShowListQueryRepositoryTest.TestConfig.class,
         ShowListQueryRepository.class,
+        ShowImagePathResolver.class,
         ShowQueryHelper.class,
         BookingStatusWindowPolicy.class,
         ShowConditionFactory.class,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 공연 상세 정보의 이미지 경로 처리 방식을 개선하여 일관된 이미지 포맷 제공.

* **Tests**
  * 공연 상세 및 목록 조회 시 이미지 경로 변환이 올바르게 작동하는지 확인하도록 테스트 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->