### PR TITLE
fix: seed data 및 소셜 로그인 URL 환경 분기 처리

### DIFF
--- a/core/core-api/src/main/java/com/ticket/core/api/controller/AuthController.java
+++ b/core/core-api/src/main/java/com/ticket/core/api/controller/AuthController.java
@@ -1,18 +1,22 @@
 package com.ticket.core.api.controller;
 
 import com.ticket.core.api.controller.docs.AuthControllerDocs;
+import com.ticket.core.config.security.SocialLoginBaseUrlResolver;
 import com.ticket.core.domain.auth.usecase.*;
 import com.ticket.core.domain.member.MemberPrincipal;
 import com.ticket.core.support.exception.AuthException;
 import com.ticket.core.support.exception.ErrorType;
 import com.ticket.core.support.response.ApiResponse;
 import com.ticket.core.support.util.CookieUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Map;
 
@@ -26,6 +30,7 @@ public class AuthController implements AuthControllerDocs {
     private final RefreshAuthTokenUseCase refreshAuthTokenUseCase;
     private final ExchangeOAuth2TokenUseCase exchangeOAuth2TokenUseCase;
     private final GetSocialLoginUrlsUseCase getSocialLoginUrlsUseCase;
+    private final SocialLoginBaseUrlResolver socialLoginBaseUrlResolver;
     private final LogoutUseCase logoutUseCase;
 
     @Override
@@ -68,9 +73,40 @@ public class AuthController implements AuthControllerDocs {
     @Override
     @GetMapping("/social/urls")
     public ApiResponse<Map<String, String>> getSocialLoginUrls() {
-        final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+        final HttpServletRequest request = currentRequest();
+        final String origin = request.getHeader("Origin");
+        final String referer = request.getHeader("Referer");
+        final String requestBaseUrl = requestBaseUrl(request);
+        final String baseUrl = socialLoginBaseUrlResolver.resolve(origin, referer, requestBaseUrl);
         final GetSocialLoginUrlsUseCase.Input input = new GetSocialLoginUrlsUseCase.Input(baseUrl);
         return ApiResponse.success(getSocialLoginUrlsUseCase.execute(input).urls());
+    }
+
+    private HttpServletRequest currentRequest() {
+        return ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+    }
+
+    private String requestBaseUrl(final HttpServletRequest request) {
+        UriComponentsBuilder builder = UriComponentsBuilder.newInstance()
+                .scheme(request.getScheme())
+                .host(request.getServerName());
+        final Integer port = serverPort(request);
+        if (port != null) {
+            builder.port(port);
+        }
+        return builder.build().toUriString();
+    }
+
+    private Integer serverPort(final HttpServletRequest request) {
+        if (isDefaultPort(request)) {
+            return null;
+        }
+        return request.getServerPort();
+    }
+
+    private boolean isDefaultPort(final HttpServletRequest request) {
+        return "http".equalsIgnoreCase(request.getScheme()) && request.getServerPort() == 80
+                || "https".equalsIgnoreCase(request.getScheme()) && request.getServerPort() == 443;
     }
 
     @Override

--- a/core/core-api/src/main/java/com/ticket/core/config/security/SocialLoginBaseUrlResolver.java
+++ b/core/core-api/src/main/java/com/ticket/core/config/security/SocialLoginBaseUrlResolver.java
@@ -1,0 +1,75 @@
+package com.ticket.core.config.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+@Component
+public class SocialLoginBaseUrlResolver {
+
+    private static final String LOCALHOST = "localhost";
+    private static final String LOOPBACK = "127.0.0.1";
+
+    private final String localBaseUrl;
+    private final String prodBaseUrl;
+    private final String fallbackBaseUrl;
+
+    public SocialLoginBaseUrlResolver(
+            @Value("${app.auth.social-login.local-base-url}") final String localBaseUrl,
+            @Value("${app.auth.social-login.prod-base-url}") final String prodBaseUrl,
+            @Value("${app.auth.public-base-url}") final String fallbackBaseUrl
+    ) {
+        this.localBaseUrl = normalize(localBaseUrl);
+        this.prodBaseUrl = normalize(prodBaseUrl);
+        this.fallbackBaseUrl = normalize(fallbackBaseUrl);
+    }
+
+    public String resolve(
+            final String origin,
+            final String referer,
+            final String requestBaseUrl
+    ) {
+        if (isLocalClient(origin) || isLocalClient(referer)) {
+            return localBaseUrl;
+        }
+        if (hasClientHost(origin) || hasClientHost(referer)) {
+            return prodBaseUrl;
+        }
+        if (hasText(requestBaseUrl)) {
+            return normalize(requestBaseUrl);
+        }
+        return fallbackBaseUrl;
+    }
+
+    private boolean isLocalClient(final String uri) {
+        final String host = extractHost(uri);
+        return LOCALHOST.equals(host) || LOOPBACK.equals(host);
+    }
+
+    private boolean hasClientHost(final String uri) {
+        return hasText(extractHost(uri));
+    }
+
+    private String extractHost(final String uri) {
+        if (!hasText(uri)) {
+            return null;
+        }
+        try {
+            return URI.create(uri).getHost();
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private boolean hasText(final String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String normalize(final String baseUrl) {
+        if (baseUrl.endsWith("/")) {
+            return baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        return baseUrl;
+    }
+}

--- a/core/core-api/src/main/java/com/ticket/core/config/seed/SeedDataLoader.java
+++ b/core/core-api/src/main/java/com/ticket/core/config/seed/SeedDataLoader.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -27,8 +29,9 @@ public class SeedDataLoader implements ApplicationRunner {
 
     private static final int DEFAULT_BATCH_SIZE = 500;
     private static final String SEED_CHECK_SQL = "SELECT COUNT(*) FROM CATEGORIES";
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss");
     private static final Pattern SHOW_INSERT_PATTERN = Pattern.compile(
-        "INSERT INTO SHOWS .*?VALUES \\((\\d+), .*?, '([0-9]{4}-[0-9]{2}-[0-9]{2})', '([0-9]{4}-[0-9]{2}-[0-9]{2})',",
+        "INSERT INTO SHOWS .*?VALUES \\((\\d+), .*?, '([0-9]{4}-[0-9]{2}-[0-9]{2})', '([0-9]{4}-[0-9]{2}-[0-9]{2})', .*?, '([0-9]{4}-[0-9]{2}-[0-9]{2}) ([0-9:]{8})', '([0-9]{4}-[0-9]{2}-[0-9]{2}) ([0-9:]{8})',",
         Pattern.DOTALL
     );
     private static final Pattern PERFORMANCE_INSERT_PATTERN = Pattern.compile(
@@ -102,32 +105,50 @@ public class SeedDataLoader implements ApplicationRunner {
             final List<PerformanceSeed> performanceSeeds = entry.getValue().stream()
                 .sorted(Comparator.comparingInt(PerformanceSeed::performanceNo))
                 .toList();
+            final ShowSeed showSeed = shows.get(entry.getKey());
+            final ShowWindow showWindow = buildShowWindow(performanceSeeds, showSeed, diversifiedStatements);
 
-            if (performanceSeeds.size() < 2 || hasMultipleDates(performanceSeeds)) {
+            if (showSeed == null) {
                 continue;
             }
 
-            final ShowSeed showSeed = shows.get(entry.getKey());
-            final LocalDate firstDate = showSeed == null ? performanceSeeds.get(0).startDate() : showSeed.startDate();
-            final int dateBucketCount = Math.min(3, performanceSeeds.size());
-            LocalDate lastAssignedDate = firstDate;
-
-            for (int index = 0; index < performanceSeeds.size(); index++) {
-                final PerformanceSeed performanceSeed = performanceSeeds.get(index);
-                final LocalDate assignedDate = firstDate.plusDays((long) index * dateBucketCount / performanceSeeds.size());
-                diversifiedStatements.set(performanceSeed.statementIndex(), rewritePerformanceStatement(performanceSeed.statement(), assignedDate));
-                lastAssignedDate = assignedDate;
-            }
-
-            if (showSeed != null && lastAssignedDate.isAfter(showSeed.endDate())) {
-                diversifiedStatements.set(
-                    showSeed.statementIndex(),
-                    rewriteShowStatement(showSeed.statement(), showSeed.endDate(), lastAssignedDate)
-                );
+            if (shouldRewriteShow(showSeed, showWindow)) {
+                diversifiedStatements.set(showSeed.statementIndex(), rewriteShowStatement(showSeed.statement(), showWindow));
             }
         }
 
         return diversifiedStatements;
+    }
+
+    private ShowWindow buildShowWindow(
+        final List<PerformanceSeed> performanceSeeds,
+        final ShowSeed showSeed,
+        final List<String> diversifiedStatements
+    ) {
+        if (performanceSeeds.size() < 2 || hasMultipleDates(performanceSeeds)) {
+            return new ShowWindow(
+                resolveEndDate(showSeed, performanceSeeds),
+                earliestOrderOpenTime(performanceSeeds),
+                latestOrderCloseTime(performanceSeeds)
+            );
+        }
+
+        final LocalDate firstDate = showSeed == null ? performanceSeeds.get(0).startDate() : showSeed.startDate();
+        final int dateBucketCount = Math.min(3, performanceSeeds.size());
+        LocalDate lastAssignedDate = firstDate;
+        LocalDateTime earliestOrderOpenTime = performanceSeeds.get(0).orderOpenTime();
+        LocalDateTime latestOrderCloseTime = performanceSeeds.get(0).orderCloseTime();
+
+        for (int index = 0; index < performanceSeeds.size(); index++) {
+            final PerformanceSeed performanceSeed = performanceSeeds.get(index);
+            final LocalDate assignedDate = firstDate.plusDays((long) index * dateBucketCount / performanceSeeds.size());
+            diversifiedStatements.set(performanceSeed.statementIndex(), rewritePerformanceStatement(performanceSeed.statement(), assignedDate));
+            lastAssignedDate = assignedDate;
+            earliestOrderOpenTime = earlierOf(earliestOrderOpenTime, performanceSeed.orderOpenTime());
+            latestOrderCloseTime = laterOf(latestOrderCloseTime, assignedDate.atTime(performanceSeed.orderCloseTime().toLocalTime()));
+        }
+
+        return new ShowWindow(resolveEndDate(showSeed, lastAssignedDate), earliestOrderOpenTime, latestOrderCloseTime);
     }
 
     private Map<Long, ShowSeed> extractShows(final List<String> statements) {
@@ -145,7 +166,9 @@ public class SeedDataLoader implements ApplicationRunner {
                 index,
                 statement,
                 LocalDate.parse(matcher.group(2)),
-                LocalDate.parse(matcher.group(3))
+                LocalDate.parse(matcher.group(3)),
+                LocalDateTime.parse(matcher.group(4) + "T" + matcher.group(5)),
+                LocalDateTime.parse(matcher.group(6) + "T" + matcher.group(7))
             ));
         }
 
@@ -166,7 +189,14 @@ public class SeedDataLoader implements ApplicationRunner {
             final int performanceNo = Integer.parseInt(matcher.group(3));
             final LocalDate startDate = LocalDate.parse(matcher.group(4));
             performancesByShow.computeIfAbsent(showId, ignored -> new ArrayList<>())
-                .add(new PerformanceSeed(index, statement, performanceNo, startDate));
+                .add(new PerformanceSeed(
+                    index,
+                    statement,
+                    performanceNo,
+                    startDate,
+                    LocalDateTime.parse(matcher.group(8) + "T" + matcher.group(9)),
+                    LocalDateTime.parse(matcher.group(10) + "T" + matcher.group(11))
+                ));
         }
 
         return performancesByShow;
@@ -177,15 +207,71 @@ public class SeedDataLoader implements ApplicationRunner {
         return performanceSeeds.stream().anyMatch(performanceSeed -> !performanceSeed.startDate().equals(firstDate));
     }
 
-    private String rewriteShowStatement(final String statement, final LocalDate currentEndDate, final LocalDate newEndDate) {
+    private boolean shouldRewriteShow(final ShowSeed showSeed, final ShowWindow showWindow) {
+        return !showSeed.endDate().equals(showWindow.endDate())
+            || !showSeed.saleStartDate().equals(showWindow.saleStartDate())
+            || !showSeed.saleEndDate().equals(showWindow.saleEndDate());
+    }
+
+    private LocalDate resolveEndDate(final ShowSeed showSeed, final List<PerformanceSeed> performanceSeeds) {
+        final LocalDate lastPerformanceDate = performanceSeeds.get(performanceSeeds.size() - 1).startDate();
+        return resolveEndDate(showSeed, lastPerformanceDate);
+    }
+
+    private LocalDate resolveEndDate(final ShowSeed showSeed, final LocalDate performanceEndDate) {
+        if (showSeed == null || performanceEndDate.isAfter(showSeed.endDate())) {
+            return performanceEndDate;
+        }
+        return showSeed.endDate();
+    }
+
+    private LocalDateTime earliestOrderOpenTime(final List<PerformanceSeed> performanceSeeds) {
+        LocalDateTime earliestOrderOpenTime = performanceSeeds.get(0).orderOpenTime();
+
+        for (PerformanceSeed performanceSeed : performanceSeeds) {
+            earliestOrderOpenTime = earlierOf(earliestOrderOpenTime, performanceSeed.orderOpenTime());
+        }
+
+        return earliestOrderOpenTime;
+    }
+
+    private LocalDateTime latestOrderCloseTime(final List<PerformanceSeed> performanceSeeds) {
+        LocalDateTime latestOrderCloseTime = performanceSeeds.get(0).orderCloseTime();
+
+        for (PerformanceSeed performanceSeed : performanceSeeds) {
+            latestOrderCloseTime = laterOf(latestOrderCloseTime, performanceSeed.orderCloseTime());
+        }
+
+        return latestOrderCloseTime;
+    }
+
+    private LocalDateTime earlierOf(final LocalDateTime current, final LocalDateTime candidate) {
+        if (candidate.isBefore(current)) {
+            return candidate;
+        }
+        return current;
+    }
+
+    private LocalDateTime laterOf(final LocalDateTime current, final LocalDateTime candidate) {
+        if (candidate.isAfter(current)) {
+            return candidate;
+        }
+        return current;
+    }
+
+    private String rewriteShowStatement(final String statement, final ShowWindow showWindow) {
         final Matcher matcher = SHOW_INSERT_PATTERN.matcher(statement);
         if (!matcher.find()) {
             return statement;
         }
 
-        return statement.substring(0, matcher.start(3))
-            + newEndDate
-            + statement.substring(matcher.end(3));
+        final StringBuilder builder = new StringBuilder(statement);
+        builder.replace(matcher.start(7), matcher.end(7), showWindow.saleEndDate().toLocalTime().format(TIME_FORMATTER));
+        builder.replace(matcher.start(6), matcher.end(6), showWindow.saleEndDate().toLocalDate().toString());
+        builder.replace(matcher.start(5), matcher.end(5), showWindow.saleStartDate().toLocalTime().format(TIME_FORMATTER));
+        builder.replace(matcher.start(4), matcher.end(4), showWindow.saleStartDate().toLocalDate().toString());
+        builder.replace(matcher.start(3), matcher.end(3), showWindow.endDate().toString());
+        return builder.toString();
     }
 
     private String rewritePerformanceStatement(final String statement, final LocalDate assignedDate) {
@@ -216,10 +302,27 @@ public class SeedDataLoader implements ApplicationRunner {
         }
     }
 
-    private record ShowSeed(int statementIndex, String statement, LocalDate startDate, LocalDate endDate) {
+    private record ShowSeed(
+        int statementIndex,
+        String statement,
+        LocalDate startDate,
+        LocalDate endDate,
+        LocalDateTime saleStartDate,
+        LocalDateTime saleEndDate
+    ) {
     }
 
-    private record PerformanceSeed(int statementIndex, String statement, int performanceNo, LocalDate startDate) {
+    private record PerformanceSeed(
+        int statementIndex,
+        String statement,
+        int performanceNo,
+        LocalDate startDate,
+        LocalDateTime orderOpenTime,
+        LocalDateTime orderCloseTime
+    ) {
+    }
+
+    private record ShowWindow(LocalDate endDate, LocalDateTime saleStartDate, LocalDateTime saleEndDate) {
     }
 
     private static final class SeedSqlLines {

--- a/core/core-api/src/main/resources/application.yml
+++ b/core/core-api/src/main/resources/application.yml
@@ -77,6 +77,9 @@ app:
     public-base-url: ${APP_AUTH_PUBLIC_BASE_URL:http://localhost:8080}
     oauth2-success-redirect-uri: ${OAUTH2_SUCCESS_REDIRECT_URI}
     oauth2-failure-redirect-uri: ${OAUTH2_FAILURE_REDIRECT_URI}
+    social-login:
+      local-base-url: ${APP_AUTH_SOCIAL_LOGIN_LOCAL_BASE_URL:http://localhost:8080}
+      prod-base-url: ${APP_AUTH_SOCIAL_LOGIN_PROD_BASE_URL:https://oneticket.site}
     kakao:
       admin-key: ${KAKAO_ADMIN_KEY}
   queue:

--- a/core/core-api/src/test/java/com/ticket/core/api/controller/AuthControllerTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/api/controller/AuthControllerTest.java
@@ -1,0 +1,121 @@
+package com.ticket.core.api.controller;
+
+import com.ticket.core.config.security.SocialLoginBaseUrlResolver;
+import com.ticket.core.domain.auth.usecase.ExchangeOAuth2TokenUseCase;
+import com.ticket.core.domain.auth.usecase.GetSocialLoginUrlsUseCase;
+import com.ticket.core.domain.auth.usecase.LoginUseCase;
+import com.ticket.core.domain.auth.usecase.LogoutUseCase;
+import com.ticket.core.domain.auth.usecase.RefreshAuthTokenUseCase;
+import com.ticket.core.domain.auth.usecase.RegisterMemberUseCase;
+import com.ticket.core.support.response.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @Mock
+    private RegisterMemberUseCase registerMemberUseCase;
+
+    @Mock
+    private LoginUseCase loginUseCase;
+
+    @Mock
+    private RefreshAuthTokenUseCase refreshAuthTokenUseCase;
+
+    @Mock
+    private ExchangeOAuth2TokenUseCase exchangeOAuth2TokenUseCase;
+
+    @Mock
+    private GetSocialLoginUrlsUseCase getSocialLoginUrlsUseCase;
+
+    @Mock
+    private LogoutUseCase logoutUseCase;
+
+    @Mock
+    private SocialLoginBaseUrlResolver socialLoginBaseUrlResolver;
+
+    private AuthController authController;
+
+    @BeforeEach
+    void setUp() {
+        authController = new AuthController(
+                registerMemberUseCase,
+                loginUseCase,
+                refreshAuthTokenUseCase,
+                exchangeOAuth2TokenUseCase,
+                getSocialLoginUrlsUseCase,
+                socialLoginBaseUrlResolver,
+                logoutUseCase
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void 로컬_프론트_origin이면_localhost_8080_기준_소셜로그인_url을_반환한다() {
+        MockHttpServletRequest request = request("https", "api.oneticket.site", 443);
+        request.addHeader("Origin", "http://localhost:3000");
+        Map<String, String> urls = Map.of("google", "http://localhost:8080/api/v1/auth/oauth2/authorize/google");
+        GetSocialLoginUrlsUseCase.Output output = new GetSocialLoginUrlsUseCase.Output(urls);
+        when(socialLoginBaseUrlResolver.resolve(any(), any(), any()))
+                .thenReturn("http://localhost:8080");
+        when(getSocialLoginUrlsUseCase.execute(any()))
+                .thenReturn(output);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        ApiResponse<Map<String, String>> response = authController.getSocialLoginUrls();
+
+        assertThat(response.getData()).isEqualTo(urls);
+        verify(socialLoginBaseUrlResolver).resolve("http://localhost:3000", null, "https://api.oneticket.site");
+    }
+
+    @Test
+    void 운영_프론트_origin이면_oneticket_site_기준_소셜로그인_url을_반환한다() {
+        MockHttpServletRequest request = request("https", "api.oneticket.site", 443);
+        request.addHeader("Origin", "https://oneticket.site");
+        Map<String, String> urls = Map.of("google", "https://oneticket.site/api/v1/auth/oauth2/authorize/google");
+        GetSocialLoginUrlsUseCase.Output output = new GetSocialLoginUrlsUseCase.Output(urls);
+        when(socialLoginBaseUrlResolver.resolve(any(), any(), any()))
+                .thenReturn("https://oneticket.site");
+        when(getSocialLoginUrlsUseCase.execute(any()))
+                .thenReturn(output);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        ApiResponse<Map<String, String>> response = authController.getSocialLoginUrls();
+
+        assertThat(response.getData()).isEqualTo(urls);
+        verify(socialLoginBaseUrlResolver).resolve("https://oneticket.site", null, "https://api.oneticket.site");
+    }
+
+    private MockHttpServletRequest request(
+            final String scheme,
+            final String serverName,
+            final int serverPort
+    ) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme(scheme);
+        request.setServerName(serverName);
+        request.setServerPort(serverPort);
+        request.setRequestURI("/api/v1/auth/social/urls");
+        return request;
+    }
+}

--- a/core/core-api/src/test/java/com/ticket/core/config/security/SocialLoginBaseUrlResolverTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/config/security/SocialLoginBaseUrlResolverTest.java
@@ -1,0 +1,43 @@
+package com.ticket.core.config.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("NonAsciiCharacters")
+class SocialLoginBaseUrlResolverTest {
+
+    private final SocialLoginBaseUrlResolver resolver = new SocialLoginBaseUrlResolver(
+            "http://localhost:8080/",
+            "https://oneticket.site/",
+            "https://api.oneticket.site/"
+    );
+
+    @Test
+    void origin이_로컬호스트면_로컬_소셜로그인_base_url을_반환한다() {
+        String result = resolver.resolve("http://localhost:3000", null, "https://api.oneticket.site");
+
+        assertThat(result).isEqualTo("http://localhost:8080");
+    }
+
+    @Test
+    void referer가_로컬호스트면_로컬_소셜로그인_base_url을_반환한다() {
+        String result = resolver.resolve(null, "http://127.0.0.1:5173/login", "https://api.oneticket.site");
+
+        assertThat(result).isEqualTo("http://localhost:8080");
+    }
+
+    @Test
+    void origin이_로컬호스트가_아니면_운영_소셜로그인_base_url을_반환한다() {
+        String result = resolver.resolve("https://www.oneticket.site", null, "https://api.oneticket.site");
+
+        assertThat(result).isEqualTo("https://oneticket.site");
+    }
+
+    @Test
+    void origin과_referer가_없으면_요청_base_url을_반환한다() {
+        String result = resolver.resolve(null, null, "https://api.oneticket.site/");
+
+        assertThat(result).isEqualTo("https://api.oneticket.site");
+    }
+}

--- a/core/core-api/src/test/java/com/ticket/core/config/seed/SeedDataLoaderTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/config/seed/SeedDataLoaderTest.java
@@ -22,11 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SeedDataLoaderTest {
 
     private static final Pattern SHOW_PATTERN = Pattern.compile(
-        "INSERT INTO SHOWS .*?VALUES \\((\\d+), .*?, '([0-9]{4}-[0-9]{2}-[0-9]{2})', '([0-9]{4}-[0-9]{2}-[0-9]{2})',",
+        "INSERT INTO SHOWS .*?VALUES \\((\\d+), .*?, '([0-9]{4}-[0-9]{2}-[0-9]{2})', '([0-9]{4}-[0-9]{2}-[0-9]{2})', .*?, '([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:]{8})', '([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:]{8})',",
         Pattern.DOTALL
     );
     private static final Pattern PERFORMANCE_PATTERN = Pattern.compile(
-        "INSERT INTO PERFORMANCES .*?VALUES \\((\\d+), (\\d+), (\\d+), '([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:]{8})'",
+        "INSERT INTO PERFORMANCES .*?VALUES \\((\\d+), (\\d+), (\\d+), '([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:]{8})', '([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:]{8})', '([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:]{8})', '([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:]{8})'",
         Pattern.DOTALL
     );
     private static final Pattern PERFORMANCE_SEAT_STATE_PATTERN = Pattern.compile(
@@ -72,6 +72,38 @@ class SeedDataLoaderTest {
                     .withFailMessage("회차 날짜가 공연 기간을 벗어났습니다. showId=%s, date=%s, period=%s", entry.getKey(), date, showPeriod)
                     .isBetween(showPeriod.startDate(), showPeriod.endDate()));
         }
+    }
+
+    @Test
+    void show_sale_start_matches_earliest_performance_order_open_time() throws Exception {
+        final List<String> statements = parseStatements();
+        final Map<Long, ShowPeriod> showPeriods = extractShowPeriods(statements);
+        final Map<Long, LocalDateTime> earliestOrderOpenByShow = extractEarliestOrderOpenByShow(statements);
+
+        assertThat(showPeriods.keySet()).containsAll(earliestOrderOpenByShow.keySet());
+
+        earliestOrderOpenByShow.forEach((showId, earliestOrderOpen) ->
+            assertThat(showPeriods.get(showId).saleStartDate())
+                .withFailMessage("공연 판매 시작 시각이 첫 회차 예매 시작 시각과 다릅니다. showId=%s, saleStart=%s, earliestOrderOpen=%s",
+                    showId, showPeriods.get(showId).saleStartDate(), earliestOrderOpen)
+                .isEqualTo(earliestOrderOpen)
+        );
+    }
+
+    @Test
+    void show_sale_end_matches_latest_performance_order_close_time() throws Exception {
+        final List<String> statements = parseStatements();
+        final Map<Long, ShowPeriod> showPeriods = extractShowPeriods(statements);
+        final Map<Long, LocalDateTime> latestOrderCloseByShow = extractLatestOrderCloseByShow(statements);
+
+        assertThat(showPeriods.keySet()).containsAll(latestOrderCloseByShow.keySet());
+
+        latestOrderCloseByShow.forEach((showId, latestOrderClose) ->
+            assertThat(showPeriods.get(showId).saleEndDate())
+                .withFailMessage("공연 판매 종료 시각이 마지막 회차 예매 마감 시각과 다릅니다. showId=%s, saleEnd=%s, latestOrderClose=%s",
+                    showId, showPeriods.get(showId).saleEndDate(), latestOrderClose)
+                .isEqualTo(latestOrderClose)
+        );
     }
 
     @Test
@@ -176,7 +208,9 @@ class SeedDataLoaderTest {
                 showId,
                 new ShowPeriod(
                     LocalDate.parse(matcher.group(2)),
-                    LocalDate.parse(matcher.group(3))
+                    LocalDate.parse(matcher.group(3)),
+                    LocalDateTime.parse(matcher.group(4).replace(' ', 'T')),
+                    LocalDateTime.parse(matcher.group(5).replace(' ', 'T'))
                 )
             );
         }
@@ -215,7 +249,54 @@ class SeedDataLoaderTest {
         return result;
     }
 
-    private record ShowPeriod(LocalDate startDate, LocalDate endDate) {
+    private Map<Long, LocalDateTime> extractEarliestOrderOpenByShow(final List<String> statements) {
+        final Map<Long, LocalDateTime> earliestOrderOpenByShow = new HashMap<>();
+
+        for (String statement : statements) {
+            final Matcher matcher = PERFORMANCE_PATTERN.matcher(statement);
+            if (!matcher.find()) {
+                continue;
+            }
+
+            final long showId = Long.parseLong(matcher.group(2));
+            final LocalDateTime orderOpenTime = LocalDateTime.parse(matcher.group(6).replace(' ', 'T'));
+            earliestOrderOpenByShow.merge(showId, orderOpenTime, this::earlierTime);
+        }
+
+        return earliestOrderOpenByShow;
+    }
+
+    private Map<Long, LocalDateTime> extractLatestOrderCloseByShow(final List<String> statements) {
+        final Map<Long, LocalDateTime> latestOrderCloseByShow = new HashMap<>();
+
+        for (String statement : statements) {
+            final Matcher matcher = PERFORMANCE_PATTERN.matcher(statement);
+            if (!matcher.find()) {
+                continue;
+            }
+
+            final long showId = Long.parseLong(matcher.group(2));
+            final LocalDateTime orderCloseTime = LocalDateTime.parse(matcher.group(7).replace(' ', 'T'));
+            latestOrderCloseByShow.merge(showId, orderCloseTime, this::laterTime);
+        }
+
+        return latestOrderCloseByShow;
+    }
+
+    private LocalDateTime laterTime(final LocalDateTime current, final LocalDateTime candidate) {
+        return candidate.isAfter(current) ? candidate : current;
+    }
+
+    private LocalDateTime earlierTime(final LocalDateTime current, final LocalDateTime candidate) {
+        return candidate.isBefore(current) ? candidate : current;
+    }
+
+    private record ShowPeriod(
+        LocalDate startDate,
+        LocalDate endDate,
+        LocalDateTime saleStartDate,
+        LocalDateTime saleEndDate
+    ) {
     }
 
     private record PerformanceDate(int performanceNo, LocalDate date) {


### PR DESCRIPTION
## Summary
- seed data의 공연 판매 관련 값을 보정하고 관련 테스트를 정리했습니다.
- `GET /api/v1/auth/social/urls` 요청/응답 계약은 유지한 채, 프론트 호출 환경에 따라 소셜 로그인 base URL을 분기하도록 수정했습니다.
- 로컬 프론트는 `http://localhost:8080`, 운영 프론트는 `https://oneticket.site` 기준으로 소셜 로그인 URL이 생성되도록 resolver와 테스트를 추가했습니다.

## Test Plan
- [x] `./gradlew :core:core-api:test --tests com.ticket.core.api.controller.AuthControllerTest --tests com.ticket.core.config.security.SocialLoginBaseUrlResolverTest --tests com.ticket.core.domain.auth.usecase.GetSocialLoginUrlsUseCaseTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 소셜 로그인 기본 URL 해석 기능을 개선하여 로컬 및 운영 환경을 더 효과적으로 구분 처리합니다.
  * 소셜 로그인을 위한 환경별 기본 URL 설정 옵션이 추가되었습니다.
  
* **개선 사항**
  * 공연 및 쇼 데이터의 날짜-시간 정보 처리 기능이 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->