### PR TITLE
chore: Datadog 관측 준비 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM eclipse-temurin:25-jre-alpine
 
+ARG DD_JAVA_AGENT_VERSION=1.60.1
+
 WORKDIR /app
 
+ADD https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${DD_JAVA_AGENT_VERSION}/dd-java-agent-${DD_JAVA_AGENT_VERSION}.jar /opt/datadog/dd-java-agent.jar
 COPY core/core-api/build/libs/*.jar app.jar
 
 EXPOSE 8080

--- a/core/core-api/build.gradle
+++ b/core/core-api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation project(':core:core-domain')
     implementation project(':support:logging')
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-restclient'
@@ -18,10 +19,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.15")
+    testImplementation 'org.springframework.boot:spring-boot-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-webmvc-test'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/core/core-api/src/main/java/com/ticket/core/config/security/SecurityConfig.java
+++ b/core/core-api/src/main/java/com/ticket/core/config/security/SecurityConfig.java
@@ -89,6 +89,8 @@ public class SecurityConfig {
                         // 정적 리소스 & 인프라
                         .requestMatchers("/", "/api/swagger-ui.html", "/api/swagger-ui/**",
                                 "/api/api-docs/**", "/ws/**","/api/images/**").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/health/**",
+                                "/actuator/info", "/actuator/prometheus").permitAll()
                         // 인증 관련 (로그아웃 제외 — 로그아웃은 인증 필요)
                         .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login",
                                 "/api/v1/auth/refresh", "/api/v1/auth/oauth2/token",

--- a/core/core-api/src/main/resources/application.yml
+++ b/core/core-api/src/main/resources/application.yml
@@ -44,6 +44,16 @@ spring:
 server:
   forward-headers-strategy: framework
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+
 springdoc:
   use-fqn: true
   default-consumes-media-type: application/json;charset=UTF-8

--- a/core/core-api/src/test/java/com/ticket/core/config/security/ActuatorSecurityConfigTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/config/security/ActuatorSecurityConfigTest.java
@@ -1,0 +1,146 @@
+package com.ticket.core.config.security;
+
+import com.ticket.core.domain.queue.runtime.QueueTicketStore;
+import com.ticket.core.domain.queue.support.QueuePolicyResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ActuatorSecurityConfigTest.TestController.class)
+@Import({SecurityConfig.class, ActuatorSecurityConfigTest.TestController.class})
+@TestPropertySource(properties = {
+        "spring.profiles.active=test",
+        "app.cors.allowed-origins=http://localhost:3000",
+        "security.jwt.secret-key=12345678901234567890123456789012",
+        "security.jwt.access-token-expiration-seconds=1800",
+        "security.jwt.refresh-token-expiration-seconds=1209600",
+        "spring.security.oauth2.client.registration.google.client-id=test-google-client-id",
+        "spring.security.oauth2.client.registration.google.client-secret=test-google-client-secret",
+        "spring.security.oauth2.client.registration.kakao.client-id=test-kakao-client-id",
+        "spring.security.oauth2.client.registration.kakao.client-secret=test-kakao-client-secret",
+        "app.auth.oauth2-success-redirect-uri=http://localhost:3000/auth/callback",
+        "app.auth.oauth2-failure-redirect-uri=http://localhost:3000/auth/callback"
+})
+@SuppressWarnings("NonAsciiCharacters")
+class ActuatorSecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private OAuth2FrontendRedirectResolver oAuth2FrontendRedirectResolver;
+
+    @MockitoBean
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @MockitoBean
+    private OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+    @MockitoBean
+    private JwtTokenService jwtTokenService;
+
+    @MockitoBean
+    private RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+
+    @MockitoBean
+    private RestAccessDeniedHandler restAccessDeniedHandler;
+
+    @MockitoBean
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+    @MockitoBean
+    private OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
+
+    @MockitoBean
+    private QueuePolicyResolver queuePolicyResolver;
+
+    @MockitoBean
+    private QueueTicketStore queueTicketStore;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Mockito.doAnswer(invocation -> {
+            HttpServletResponse response = invocation.getArgument(1);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return null;
+        }).when(restAuthenticationEntryPoint).commence(Mockito.any(), Mockito.any(), Mockito.any());
+
+        Mockito.doAnswer(invocation -> {
+            HttpServletResponse response = invocation.getArgument(1);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            return null;
+        }).when(restAccessDeniedHandler).handle(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void actuator_prometheus는_인증_없이_접근할_수_있다() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+                .andExpect(content().string("prometheus"));
+    }
+
+    @Test
+    void actuator_health는_인증_없이_접근할_수_있다() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("health"));
+    }
+
+    @Test
+    void actuator_info는_인증_없이_접근할_수_있다() throws Exception {
+        mockMvc.perform(get("/actuator/info"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("info"));
+    }
+
+    @Test
+    void 일반_api는_인증_없이_접근할_수_없다() throws Exception {
+        mockMvc.perform(get("/api/v1/private-test"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @RestController
+    public static class TestController {
+
+        @GetMapping(value = "/actuator/prometheus", produces = MediaType.TEXT_PLAIN_VALUE)
+        public String prometheus() {
+            return "prometheus";
+        }
+
+        @GetMapping("/actuator/health")
+        public String health() {
+            return "health";
+        }
+
+        @GetMapping("/actuator/info")
+        public String info() {
+            return "info";
+        }
+
+        @GetMapping("/api/v1/private-test")
+        public String privateApi() {
+            return "private";
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-04-01-datadog-docker-compose.md
+++ b/docs/superpowers/plans/2026-04-01-datadog-docker-compose.md
@@ -1,0 +1,57 @@
+# Datadog Docker Compose Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Docker Compose 기반 운영 서버에서 Datadog Agent 중심 구조를 붙일 수 있도록 애플리케이션 코드와 이미지 준비를 완료한다.
+
+**Architecture:** `core-api`는 Actuator Prometheus endpoint를 노출하고 stdout 로그를 유지한다. Docker 이미지는 `dd-java-agent.jar`를 포함하되, 실제 trace 활성화와 Agent 수집 설정은 운영 compose에서 제어한다.
+
+**Tech Stack:** Spring Boot Actuator, Micrometer Prometheus, Spring Security, Docker, Datadog Java Agent, JUnit 5, MockMvc
+
+---
+
+## Chunk 1: 앱 관측 endpoint 준비
+
+### Task 1: actuator 보안 정책 테스트 추가
+
+**Files:**
+- Create: `core/core-api/src/test/java/com/ticket/core/config/security/ActuatorSecurityConfigTest.java`
+
+- [ ] `@WebMvcTest` 기반 테스트를 추가한다.
+- [ ] `/actuator/health`, `/actuator/info`, `/actuator/prometheus`는 인증 없이 접근 가능하다는 실패 테스트를 먼저 작성한다.
+- [ ] 비공개 API는 계속 `401`이라는 테스트를 함께 둔다.
+- [ ] 관련 테스트만 실행해 red를 확인한다.
+
+### Task 2: actuator와 prometheus endpoint 노출 구현
+
+**Files:**
+- Modify: `core/core-api/build.gradle`
+- Modify: `core/core-api/src/main/resources/application.yml`
+- Modify: `core/core-api/src/main/java/com/ticket/core/config/security/SecurityConfig.java`
+
+- [ ] `spring-boot-starter-actuator`와 `micrometer-registry-prometheus`를 추가한다.
+- [ ] `health`, `info`, `prometheus` endpoint만 노출하도록 설정한다.
+- [ ] actuator 경로를 최소 허용 경로에 추가한다.
+- [ ] Task 1 테스트를 다시 실행해 green을 확인한다.
+
+## Chunk 2: Docker 이미지에 Java tracer 준비
+
+### Task 3: Datadog Java agent 포함 테스트 가능한 구조로 정리
+
+**Files:**
+- Modify: `Dockerfile`
+
+- [ ] `dd-java-agent.jar`를 이미지에 포함하되 기본 실행 흐름은 유지하는 방향으로 수정한다.
+- [ ] 운영 compose에서 `JAVA_TOOL_OPTIONS=-javaagent:...`만 주입하면 trace가 켜질 수 있게 만든다.
+- [ ] 불필요한 런타임 변경 없이 기존 이미지 실행 방식이 유지되는지 확인한다.
+
+## Chunk 3: 검증
+
+### Task 4: 변경 검증
+
+**Files:**
+- Test: `core/core-api/src/test/java/com/ticket/core/config/security/ActuatorSecurityConfigTest.java`
+
+- [ ] `./gradlew :core:core-api:test --tests com.ticket.core.config.security.ActuatorSecurityConfigTest`를 실행한다.
+- [ ] `./gradlew :core:core-api:compileJava`를 실행한다.
+- [ ] 결과를 확인하고 남은 운영 compose 반영 항목을 정리한다.

--- a/docs/superpowers/specs/2026-04-01-datadog-docker-compose-design.md
+++ b/docs/superpowers/specs/2026-04-01-datadog-docker-compose-design.md
@@ -1,0 +1,64 @@
+# Datadog Docker Compose Design
+
+## 목표
+
+`oneticket.site` 운영 서버의 Docker Compose 환경에 Datadog을 도입해 아래 항목을 한 번에 관측 가능하게 만든다.
+
+- `ticket-be` 애플리케이션 메트릭
+- `ticket-be` 애플리케이션 로그
+- `ticket-be` APM trace
+- Docker/호스트 인프라 메트릭
+
+## 현재 구조
+
+- 애플리케이션은 Ubuntu 서버에서 `docker compose`로 배포된다.
+- 저장소의 [docker-compose.yml](C:\Users\mn040\IdeaProjects\ticket\docker-compose.yml)은 로컬 Redis만 포함하고, 실제 운영 배포는 GitHub Actions가 서버의 `/home/ubuntu/docker-compose.yml`을 사용한다.
+- [Dockerfile](C:\Users\mn040\IdeaProjects\ticket\Dockerfile)은 Spring Boot fat jar만 복사해 실행한다.
+- [logback-prod.xml](C:\Users\mn040\IdeaProjects\ticket\support\logging\src\main\resources\logback\logback-prod.xml)은 stdout 로그를 사용하고 `traceId`, `spanId` MDC 자리를 이미 포함한다.
+- [core-api/build.gradle](C:\Users\mn040\IdeaProjects\ticket\core\core-api\build.gradle)에는 아직 Actuator/Prometheus 의존성이 없다.
+
+## 설계
+
+### 1. Agent 중심 수집 구조를 사용한다
+
+- 운영 compose에 `datadog-agent` 컨테이너를 추가한다.
+- `ticket-be` 컨테이너는 Datadog SaaS와 직접 통신하지 않고 같은 compose 네트워크의 `datadog-agent`로 trace를 보낸다.
+- 메트릭과 로그도 Agent가 수집해 Datadog으로 전송한다.
+
+### 2. 애플리케이션은 관측 데이터만 노출한다
+
+- Spring Boot는 `/actuator/prometheus`를 노출해 Agent가 scrape 가능하게 만든다.
+- stdout 로그는 그대로 유지하고 Agent가 Docker 로그를 수집한다.
+- Java APM은 `dd-java-agent.jar`를 이미지에 포함하고, 운영 compose에서 `-javaagent`를 활성화한다.
+
+### 3. 운영 compose가 최종 제어 지점이 된다
+
+- Datadog API key, site, `DD_SERVICE`, `DD_ENV`, `DD_VERSION`은 운영 compose 또는 서버 환경변수에서 관리한다.
+- Docker socket, `/proc`, `/sys/fs/cgroup` 등을 Agent 컨테이너에 마운트해 Docker/호스트 메트릭을 수집한다.
+- 서비스/환경 태그는 `ticket-be`, `prod` 기준으로 통일한다.
+
+## 코드 변경 범위
+
+- [core/core-api/build.gradle](C:\Users\mn040\IdeaProjects\ticket\core\core-api\build.gradle)
+  - Actuator/Prometheus 의존성 추가
+- [core/core-api/src/main/resources/application.yml](C:\Users\mn040\IdeaProjects\ticket\core\core-api\src\main\resources\application.yml)
+  - `health`, `info`, `prometheus` endpoint 노출
+- [core/core-api/src/main/java/com/ticket/core/config/security/SecurityConfig.java](C:\Users\mn040\IdeaProjects\ticket\core\core-api\src\main\java\com\ticket\core\config\security\SecurityConfig.java)
+  - actuator endpoint 허용
+- [Dockerfile](C:\Users\mn040\IdeaProjects\ticket\Dockerfile)
+  - `dd-java-agent.jar` 포함
+
+## 운영 변경 범위
+
+- 서버 `/home/ubuntu/docker-compose.yml`에 `datadog-agent` 추가
+- `ticket-be` 컨테이너에 Datadog 환경변수와 `JAVA_TOOL_OPTIONS` 추가
+- Datadog Agent에 Docker/host/APM/log collection 활성화
+
+## 리스크와 대응
+
+- `dd-java-agent` 경로 오류로 앱 기동 실패 가능
+  - 이미지에 jar를 명시적으로 포함하고 compose에서만 활성화한다.
+- `/actuator/prometheus`가 Spring Security에 막힐 수 있다.
+  - actuator 경로만 최소 허용한다.
+- 로그/트레이스 상관관계가 깨질 수 있다.
+  - `service`, `env`, `version` 값을 compose에서 단일 기준으로 맞춘다.


### PR DESCRIPTION
## 변경 사항
- Datadog 도입 계획/설계 문서를 추가했습니다.
- `core-api`에 Actuator, Prometheus 의존성과 endpoint 노출 설정을 추가했습니다.
- 보안 설정에서 `/actuator/health`, `/actuator/info`, `/actuator/prometheus`를 인증 없이 허용했습니다.
- Docker 이미지에 Datadog Java agent를 포함하도록 `Dockerfile`을 조정했습니다.
- actuator 공개 경로 보안 테스트를 추가했습니다.

## 검증
- `./gradlew :core:core-api:test --tests com.ticket.core.config.security.ActuatorSecurityConfigTest`
- `./gradlew :core:core-api:compileJava`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 헬스 체크, 정보, 프로메테우스 메트릭 엔드포인트를 통한 애플리케이션 모니터링 기능 추가
  * 마이크로미터 프로메테우스를 통한 상세한 메트릭 수집 및 내보내기 지원 추가
  * Datadog Java Agent 통합을 위한 Docker 이미지 빌드 지원 추가로 애플리케이션 추적 및 성능 모니터링 강화
  * 모니터링 엔드포인트에 대한 보안 정책 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->