### PR TITLE
fix(order): OrderExpirationScheduler 만료 처리 구조화 로그 추가

### DIFF
--- a/core/core-domain/src/main/java/com/ticket/core/domain/order/command/expire/OrderExpirationScheduler.java
+++ b/core/core-domain/src/main/java/com/ticket/core/domain/order/command/expire/OrderExpirationScheduler.java
@@ -53,10 +53,12 @@ public class OrderExpirationScheduler {
         int processedCount = 0;
         for (final Order order : expiredOrders.getContent()) {
             try {
+                log.info("주문 만료 처리 시작 orderId={}, orderKey={}", order.getId(), order.getOrderKey());
                 expireOrderUseCase.expireByOrderId(order.getId(), now);
+                log.info("주문 만료 처리 완료 orderId={}, orderKey={}", order.getId(), order.getOrderKey());
                 processedCount++;
             } catch (final RuntimeException e) {
-                log.error("주문 만료 처리 실패: orderKey={}, orderId={}", order.getOrderKey(), order.getId(), e);
+                log.warn("주문 만료 처리 실패 orderId={}, orderKey={}", order.getId(), order.getOrderKey(), e);
             }
         }
         return processedCount;

--- a/core/core-domain/src/test/java/com/ticket/core/domain/order/command/expire/OrderExpirationSchedulerTest.java
+++ b/core/core-domain/src/test/java/com/ticket/core/domain/order/command/expire/OrderExpirationSchedulerTest.java
@@ -52,8 +52,8 @@ class OrderExpirationSchedulerTest {
     void due_orders_are_expired_with_clock_now() {
         OrderExpirationScheduler scheduler = new OrderExpirationScheduler(expireOrderUseCase, orderRepository, fixedClock);
         LocalDateTime expectedNow = LocalDateTime.of(2026, 3, 15, 10, 0);
-        Order first = createOrder(1L, null);
-        Order second = createOrder(2L, null);
+        Order first = createOrder(1L, "order-1");
+        Order second = createOrder(2L, "order-2");
         Slice<Order> slice = new SliceImpl<>(List.of(first, second));
         when(orderRepository.findAllByStatusAndExpiresAtBefore(eq(OrderState.PENDING), eq(expectedNow), any()))
                 .thenReturn(slice);


### PR DESCRIPTION
## Summary
- OrderExpirationScheduler에서 만료 처리 시작/완료/실패 시 `orderId`, `orderKey`를 포함한 구조화 로그 추가
- 기존 실패 로그 레벨을 `error` → `warn`으로 변경, 파라미터 순서를 `orderId, orderKey`로 통일
- 테스트의 Order 스텁에 `orderKey`를 추가하여 로그 출력과 일관되게 수정

## Test plan
- [x] `./gradlew :core:core-domain:test` 전체 통과 확인
- [x] `./scripts/verify-fix.sh` 실행 — 빌드/부팅/도메인 테스트 정상 (인증 관련 기존 실패 4건은 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)