### PR TITLE
chore(ci): Claude 워크플로우 이벤트 축소 및 쓰기 권한 부여

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,8 +3,6 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
   issues:
     types: [opened, assigned]
   pull_request_review:
@@ -14,14 +12,13 @@ jobs:
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- `claude.yml` 에서 `pull_request_review_comment` 트리거 제거 — 리뷰 인라인 코멘트가 달릴 때마다 워크플로우가 기동되어 `skipped` run이 대량으로 쌓이는 원인 제거
- `claude.yml`, `claude-code-review.yml` 의 `pull-requests`, `issues` 권한을 `read` → `write` 로 상향

## 배경
- 현재 Actions 탭에 `Claude Code` 워크플로우 `skipped` run이 PR 리뷰 이벤트마다 누적됨
- `Claude Code Review` 는 PR 열 때 `completed success` 로 끝나지만 **실제 리뷰 코멘트가 게시되지 않음**
  - PR #164 실행 로그 기준: `num_turns=27`, `total_cost_usd=0.71`, `permission_denials_count=20`, `No buffered inline comments`
  - 원인: 권한이 `pull-requests: read`, `issues: read` 로 설정되어 있어 Claude가 리뷰/코멘트를 **쓰지 못함** → 20번의 permission denial 후 조용히 종료

## 영향
- 기존 `@claude` 멘션 트리거는 유지됨 (일반 issue/PR comment, PR review submit, issue open/assign)
- PR 리뷰 인라인 코멘트에서 `@claude` 멘션은 더 이상 트리거되지 않음 — 필요하면 일반 PR comment로 멘션하면 됨
- 병합 후 다음 PR부터 Claude 리뷰가 정상 게시되는지 확인 필요

## Test plan
- [ ] 병합 후 새 PR을 열어 `Claude Code Review` 워크플로우가 실제로 리뷰 코멘트를 게시하는지 확인
- [ ] Actions 탭에서 `Claude Code` workflow의 skipped run 누적이 감소하는지 확인
- [ ] PR comment 에 `@claude` 멘션 시 응답 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * GitHub Actions 워크플로우 설정이 업데이트되었습니다. 자동화된 코드 리뷰 프로세스의 접근 권한 및 트리거 조건이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->