### PR TITLE
fix(hold): RSetCache에 LongCodec 명시 (#172)

### DIFF
--- a/core/core-domain/src/main/java/com/ticket/core/domain/hold/infra/RedissonHoldStore.java
+++ b/core/core-domain/src/main/java/com/ticket/core/domain/hold/infra/RedissonHoldStore.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RBucket;
 import org.redisson.api.RSetCache;
 import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.StringCodec;
 import org.springframework.stereotype.Component;
 
@@ -94,7 +95,7 @@ public class RedissonHoldStore implements HoldStore {
     }
 
     private RSetCache<Long> holdSeatIndex(final Long performanceId) {
-        return redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(performanceId));
+        return redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(performanceId), LongCodec.INSTANCE);
     }
 
     private HoldSnapshot readSnapshot(final String holdKey) {

--- a/core/core-domain/src/main/java/com/ticket/core/domain/performanceseat/query/GetSeatStatusUseCase.java
+++ b/core/core-domain/src/main/java/com/ticket/core/domain/performanceseat/query/GetSeatStatusUseCase.java
@@ -42,7 +42,7 @@ public class GetSeatStatusUseCase {
         }
 
         final List<SeatStateView> merged = dbStates.stream()
-                .map(seat -> seat.status() == SeatStatus.AVAILABLE && redisOccupiedIds.contains(seat.seatId())
+                .map(seat -> redisOccupiedIds.contains(seat.seatId())
                         ? new SeatStateView(seat.seatId(), SeatStatus.OCCUPIED)
                         : seat)
                 .toList();

--- a/core/core-domain/src/test/java/com/ticket/core/domain/hold/store/RedissonHoldStoreTest.java
+++ b/core/core-domain/src/test/java/com/ticket/core/domain/hold/store/RedissonHoldStoreTest.java
@@ -12,6 +12,7 @@ import org.redisson.api.RBucket;
 import org.redisson.api.RKeys;
 import org.redisson.api.RSetCache;
 import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.LongCodec;
 import org.redisson.client.codec.StringCodec;
 
 import java.time.Duration;
@@ -55,7 +56,7 @@ class RedissonHoldStoreTest {
         when(redissonClient.getBucket(SeatRedisKey.hold(1L, 10L), StringCodec.INSTANCE)).thenReturn(seat10);
         when(redissonClient.getBucket(SeatRedisKey.hold(1L, 20L), StringCodec.INSTANCE)).thenReturn(seat20);
         when(redissonClient.getBucket(SeatRedisKey.holdMeta("hold-key"), StringCodec.INSTANCE)).thenReturn(meta);
-        when(redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(1L))).thenReturn(holdSeatIndex);
+        when(redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(1L), LongCodec.INSTANCE)).thenReturn(holdSeatIndex);
         when(holdSnapshotCodec.encode(any(HoldSnapshot.class))).thenReturn("payload");
 
         //when
@@ -83,7 +84,7 @@ class RedissonHoldStoreTest {
         when(redissonClient.getBucket(SeatRedisKey.hold(1L, 10L), StringCodec.INSTANCE)).thenReturn(seat10);
         when(redissonClient.getBucket(SeatRedisKey.hold(1L, 20L), StringCodec.INSTANCE)).thenReturn(seat20);
         when(redissonClient.getBucket(SeatRedisKey.holdMeta("hold-key"), StringCodec.INSTANCE)).thenReturn(meta);
-        when(redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(1L))).thenReturn(holdSeatIndex);
+        when(redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(1L), LongCodec.INSTANCE)).thenReturn(holdSeatIndex);
         doThrow(new RuntimeException("boom")).when(seat20).set("hold-key", ttl);
 
         //when
@@ -108,7 +109,7 @@ class RedissonHoldStoreTest {
         when(redissonClient.getBucket(SeatRedisKey.hold(1L, 10L), StringCodec.INSTANCE)).thenReturn(seat10);
         when(redissonClient.getBucket(SeatRedisKey.hold(1L, 20L), StringCodec.INSTANCE)).thenReturn(seat20);
         when(redissonClient.getBucket(SeatRedisKey.holdMeta("hold-key"), StringCodec.INSTANCE)).thenReturn(meta);
-        when(redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(1L))).thenReturn(holdSeatIndex);
+        when(redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(1L), LongCodec.INSTANCE)).thenReturn(holdSeatIndex);
         when(meta.get()).thenReturn("{\"holdKey\":\"hold-key\",\"memberId\":7,\"performanceId\":1,\"seatIds\":[10,20],\"expiresAt\":\"2026-03-15T19:05:00\"}");
         when(holdSnapshotCodec.decode("{\"holdKey\":\"hold-key\",\"memberId\":7,\"performanceId\":1,\"seatIds\":[10,20],\"expiresAt\":\"2026-03-15T19:05:00\"}"))
                 .thenReturn(new HoldSnapshot("hold-key", 7L, 1L, List.of(10L, 20L), LocalDateTime.of(2026, 3, 15, 19, 5)));
@@ -134,7 +135,7 @@ class RedissonHoldStoreTest {
         when(redissonClient.getBucket(SeatRedisKey.hold(1L, 10L), StringCodec.INSTANCE)).thenReturn(seat10);
         when(redissonClient.getBucket(SeatRedisKey.hold(1L, 20L), StringCodec.INSTANCE)).thenReturn(seat20);
         when(redissonClient.getBucket(SeatRedisKey.holdMeta("hold-key"), StringCodec.INSTANCE)).thenReturn(meta);
-        when(redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(1L))).thenReturn(holdSeatIndex);
+        when(redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(1L), LongCodec.INSTANCE)).thenReturn(holdSeatIndex);
         when(meta.get()).thenReturn(payload);
         when(holdSnapshotCodec.decode(payload))
                 .thenReturn(new HoldSnapshot("hold-key", 7L, 1L, List.of(10L, 20L), LocalDateTime.of(2026, 3, 15, 19, 5)));
@@ -153,7 +154,7 @@ class RedissonHoldStoreTest {
         //given
         @SuppressWarnings("unchecked")
         RSetCache<Object> holdSeatIndex = mock(RSetCache.class);
-        when(redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(1L))).thenReturn(holdSeatIndex);
+        when(redissonClient.getSetCache(SeatRedisKey.holdSeatIndex(1L), LongCodec.INSTANCE)).thenReturn(holdSeatIndex);
         when(holdSeatIndex.readAll()).thenReturn(Set.of(30L, 10L));
 
         //when


### PR DESCRIPTION
Closes #172

> PR #173을 대체합니다 — base branch가 `master`가 아닌 `main`으로 잘못 설정되어 불필요한 파일 변경이 83개 포함됐던 문제를 수정

## Summary

- `RedissonHoldStore.holdSeatIndex` 헬퍼에 `LongCodec.INSTANCE`를 명시해 글로벌 `StringCodec`으로 떨어지는 fallback 차단
- `GetSeatStatusUseCase.execute`의 merge 가지치기를 단순화 (status 가드 제거 — 의미적으로 동일)
- 관련 테스트(`RedissonHoldStoreTest`)의 mock 셋업에 `LongCodec.INSTANCE` 인자 추가

## Why

기존 코드는 `redissonClient.getSetCache(key)`로 코덱을 명시하지 않아 `RedissonConfig`의 글로벌 `StringCodec`이 상속됐다. 결과:

- `holdSeatIndex.add(501L, ...)` → Redis에는 "501" 텍스트로 저장 (값은 정상)
- `holdSeatIndex.readAll()` → 반환 객체는 `Long`이 아닌 **`String`** (제네릭 type erasure로 검증 불가)
- `GetSeatStatusUseCase.mergeRedisOccupiedIds`의 `HashSet`이 select(Long)와 hold(String) 혼합 보유
- `redisOccupiedIds.contains(seat.seatId())`에서 `Long.hashCode(501)=501` ≠ `String.hashCode("501")=53486`으로 즉시 false

→ hold 좌석이 응답에서 `OCCUPIED`로 승격되지 못해 좌석맵 회색 처리가 누락되는 사용자 영향.

## Test plan

- [x] `RedissonHoldStoreTest` 6건 통과
- [x] `com.ticket.core.domain.hold.*` / `performanceseat.*` / `order.*` 도메인 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 예약 시스템에서 좌석 상태 판단 로직을 개선하여 Redis 데이터의 우선순위를 강화했습니다.

* **리팩토링**
  * 좌석 ID 저장소의 데이터 인코딩 처리를 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->