### PR TITLE
chore(ci): Claude 리뷰 workflow 브랜치 조건 동기화

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,6 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
+    branches: [ "master", "develop" ]
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:


### PR DESCRIPTION
## 변경 사항
- `master`의 `.github/workflows/claude-code-review.yml`에 `branches: [ "master", "develop" ]` 조건을 추가했습니다.
- `develop`의 동일 workflow 파일과 내용이 일치하도록 맞췄습니다.

## 이유
- Claude Code Review 액션이 OIDC 앱 토큰을 교환할 때 workflow 파일이 default branch(`master`)의 파일과 동일해야 합니다.
- 현재 `develop`과 `master`의 workflow 파일이 달라 PR #185의 Claude review job이 `Workflow validation failed`로 실패하고 있습니다.

## 검증
- staged diff: workflow 파일 1개, 1줄 추가
- `git diff --cached --check` 통과
- local workflow 파일 해시가 `origin/develop:.github/workflows/claude-code-review.yml`와 동일함을 확인했습니다.