### PR TITLE
chore(ci): AWS EC2 배포 경로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,12 +54,12 @@ jobs:
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.HOST_IP }}
-          username: root
+          username: ubuntu
           key: ${{ secrets.SSH_KEY }}
           script: |
             set -e
             IMAGE="${{ secrets.DOCKER_USERNAME }}/ticket-be:latest"
-            DEPLOY_DIR="/root"
+            DEPLOY_DIR="/home/ubuntu/ticket-core"
             CURRENT_FE_IMAGE="$(sudo docker inspect ticket-fe --format '{{.Config.Image}}' 2>/dev/null || true)"
 
             if [ -z "$CURRENT_FE_IMAGE" ]; then


### PR DESCRIPTION
## 변경 사항

- GitHub Actions SSH 배포 사용자를 `root`에서 AWS Ubuntu AMI 기본 사용자 `ubuntu`로 변경했습니다.
- 서버 배포 디렉터리를 `/root`에서 `/home/ubuntu/ticket-core`로 변경했습니다.

## 변경 이유

DigitalOcean에서 AWS EC2로 core 서버를 이전하면서 새 인스턴스의 사용자와 파일 배치 경로에 배포 workflow를 맞춰야 합니다.

## 영향

- 애플리케이션 코드와 컨테이너 구성에는 변화가 없습니다.
- GitHub Actions의 배포 대상 경로만 변경됩니다.
- 배포 전에 저장소의 `HOST_IP`와 `SSH_KEY` GitHub Secrets를 AWS EC2 정보로 갱신해야 합니다.

## 검증

- `git diff --check` 통과
- 변경 파일이 `.github/workflows/deploy.yml` 하나인지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **배포**
  * Ubuntu 서버 배포 시 올바른 사용자 계정과 배포 경로를 사용하도록 수정했습니다.
  * Docker Compose 기반 배포가 지정된 애플리케이션 디렉터리에서 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->