### PR TITLE
현재 아키텍처·운영 문서 최신화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 4. `docs/operations.md`
 5. 관련 모듈의 `build.gradle`, `settings.gradle`, 테스트 코드
 
-부하 테스트나 예매 오픈 검증은 `docs/load-test.md`와 `docs/load-test/` 하위 문서를 함께 본다.
+부하 테스트나 예매 오픈 검증은 `docs/load-test.md`에서 시작하고, 실제 시나리오와 실행 옵션은 형제 저장소 `../gatling-test`의 `README.md`와 `console/README.md`를 기준으로 본다. 이 저장소의 `load-tests/gatling`은 이전 시나리오 보관본이다.
 
 ## 저장소를 읽는 순서
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ticket Backend
 
-기준일: 2026-05-24
+기준일: 2026-07-30
 
 공연/전시 티켓 예매 백엔드다. 인증, 공연 조회, 좌석 선택, 좌석 선점, 주문 시작/취소/만료를 Spring Boot 멀티 모듈 구조로 다룬다. 대기열 처리는 현재 `ticket-queue` 별도 서버로 분리되어 있으며, 이 서버는 Queue Server가 발급한 admission token을 검증해 예매 API 진입을 제어한다.
 
@@ -24,7 +24,7 @@
 | 현재 기능과 API 흐름 | `docs/development.md` |
 | 모듈 책임과 패키지 경계 | `docs/architecture.md` |
 | 실행, 프로파일, 검증 | `docs/operations.md` |
-| 부하 테스트 진입점 | `docs/load-test.md`, `docs/load-test/` |
+| 부하 테스트 진입점 | `docs/load-test.md`, 형제 저장소 `../gatling-test` |
 | Gradle 모듈 경계 | `settings.gradle` |
 
 ## 모듈 구조
@@ -38,10 +38,9 @@ ticket
 ├── storage
 │   └── redis-core     # Redis/Redisson 공통 의존성
 ├── support
-│   ├── logging        # 공통 로깅 리소스
-│   └── security       # JWT/admission token 공통 보안 유틸
+│   └── logging        # 공통 로깅 리소스
 ├── load-tests
-│   └── gatling        # Gatling 부하 테스트 프로젝트
+│   └── gatling        # 이전 시나리오 보관본; 현재 실행 기준은 ../gatling-test
 └── docs               # 개발/아키텍처/운영/부하 테스트 문서
 ```
 
@@ -113,11 +112,30 @@ $env:JWT_ACCESS_TOKEN_EXPIRATION_SECONDS="1800"
 $env:JWT_REFRESH_TOKEN_EXPIRATION_SECONDS="1209600"
 $env:ADMISSION_TOKEN_SECRET_KEY="replace-with-shared-admission-secret"
 $env:ADMISSION_TOKEN_ENFORCEMENT_ENABLED="false"
+$env:GOOGLE_CLIENT_ID="local-google-client-id"
+$env:GOOGLE_CLIENT_SECRET="local-google-client-secret"
+$env:KAKAO_CLIENT_ID="local-kakao-client-id"
+$env:KAKAO_CLIENT_SECRET="local-kakao-client-secret"
+$env:KAKAO_ADMIN_KEY="local-kakao-admin-key"
 
 .\gradlew.bat :core:core-api:bootRun
 ```
 
-OAuth2 로그인을 실제로 확인하려면 `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET`, `KAKAO_ADMIN_KEY`도 설정한다.
+위 OAuth2 값은 로컬 기동용 예시다. 실제 OAuth2 로그인을 확인하려면 각 공급자에서 발급받은 로컬 callback용 값으로 교체한다.
+### Queue active session 조기 반환(선택)
+
+현재 구현의 예매 종료점인 `PENDING` 주문 생성이 성공하면 admission token의 `queueId`를 이용해 Queue Server의 active session 완료 API를 비동기로 호출할 수 있다. 기본값은 비활성화이며, 콜백 실패가 주문 성공을 되돌리지는 않는다. 이 경우 Queue Server의 shopping session TTL이 안전망으로 session을 정리한다. 결제 API가 추가되면 반환 시점을 주문 생성이 아니라 결제 성공·실패·취소 같은 최종 상태로 옮겨야 한다.
+
+```powershell
+$env:QUEUE_COMPLETION_ENABLED="true"
+$env:QUEUE_SERVER_BASE_URL="http://localhost:8090"
+$env:QUEUE_COMPLETION_SECRET="same-queue-completion-secret-32bytes-minimum"
+$env:QUEUE_COMPLETION_CONNECT_TIMEOUT="500ms"
+$env:QUEUE_COMPLETION_READ_TIMEOUT="1s"
+```
+
+활성화할 때 `QUEUE_COMPLETION_SECRET`은 32자 이상이어야 하며 `ticket-queue`와 같은 값을 사용해야 한다.
+
 
 ## 주요 설정
 
@@ -156,4 +174,5 @@ OAuth2 로그인을 실제로 확인하려면 `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT
 - README는 전체 맥락만 담고, 세부 규칙은 `AGENTS.md`와 `docs/`를 우선한다.
 - `auth`, `hold`, `order`, `performanceseat`, `queue` 관련 변경은 동시성, 트랜잭션, Redis TTL, 만료 listener/scheduler, admission token 검증을 함께 확인한다.
 - 기존 미커밋 변경은 사용자 작업으로 보고 되돌리지 않는다.
-- `load-tests/gatling` 실행은 실제 부하를 만들 수 있으므로 사용자가 명시적으로 요청한 경우에만 다룬다.
+- 현재 부하 테스트 실행 기준은 형제 저장소 `../gatling-test`다. 이 저장소의 `load-tests/gatling`은 이전 시나리오 보관본이므로 새 실행 기준으로 사용하지 않는다.
+- Gatling 실행은 실제 부하를 만들 수 있으므로 사용자가 명시적으로 요청한 경우에만 다룬다.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,14 +6,13 @@
 
 현재 프로젝트는 멀티 모듈 Gradle 구조이며, 실행/API, 도메인/application, 기술 구현을 점진적으로 분리하는 모듈러 모놀리스에 가깝다.
 
-실제 포함 모듈은 다음 6개다.
+실제 포함 모듈은 다음 5개다.
 
 - `core:core-api`
 - `core:core-domain`
 - `core:core-infra`
 - `storage:redis-core`
 - `support:logging`
-- `support:security`
 
 ## 모듈 책임
 
@@ -83,16 +82,6 @@ Redis 관련 공통 의존성을 제공한다.
 
 로깅 관련 공통 설정 리소스를 제공한다.
 
-### `support:security`
-
-JWT, Internal Auth, Admission Token 등 공통 보안 유틸을 제공하는 라이브러리 모듈이다. `maven-publish`로 발행되며, `core-api`가 이 모듈의 토큰 발급/검증 컴포넌트를 사용한다.
-
-주요 책임:
-
-- 사용자 Access Token 발급/검증 (`JwtAccessTokenIssuer`, `JwtTokenVerifier`)
-- 서비스 로컬 principal 기반 Access Token 검증
-- Admission Token 발급/검증 (`AdmissionTokenService`)
-
 ## 패키지 구조
 
 ### `core-api`
@@ -108,7 +97,7 @@ JWT, Internal Auth, Admission Token 등 공통 보안 유틸을 제공하는 라
 - `com.ticket.core.config.security`
   - JWT, OAuth2, 인증/인가 구성
 - `com.ticket.core.config.admission`
-  - Admission token 검증 설정
+  - Admission token 설정·발급·검증과 Queue active session 완료 비동기 알림
 - `com.ticket.core.support.response`
   - 공통 응답 래퍼
 
@@ -199,7 +188,7 @@ JPA entity와 Spring Data repository는 대부분 `core-domain`에 존재한다.
 
 ### Redis
 
-Redis는 짧은 수명 상태와 동시성 제어, 토큰 저장, 실시간 좌석 처리에 사용한다. 대기열 Redis는 `ticket-queue`에서 별도 Redis Cluster로 운영한다.
+Redis는 짧은 수명 상태와 동시성 제어, 토큰 저장, 실시간 좌석 처리에 사용한다. 대기열 상태는 `ticket-queue`가 별도 Redis에서 관리하며, 현재 애플리케이션과 배포 설정은 단일 Redis 서버를 사용한다.
 
 주요 대상:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,7 +11,7 @@ Ticket은 공연/전시 티켓팅 백엔드다. 현재 구현의 중심은 아�
 - 좌석 선택: Redis TTL 기반 임시 선택 상태와 WebSocket 전파
 - 좌석 선점: Redis 기반 hold와 주문 시작 흐름
 - 주문: `PENDING` 주문 생성, 조회, 취소, 만료 처리
-- 대기열: Ticket Server가 회차별 DIRECT/QUEUE를 결정하고, `ticket-queue` 별도 서비스가 Redis Cluster 기반 waiting/active/session 상태와 admission token 발급을 담당
+- 대기열: Ticket Server가 회차별 DIRECT/QUEUE를 결정하고, `ticket-queue` 별도 서비스가 shard/local sequence와 public state 기반 대기 상태 및 admission token 발급을 담당
 
 결제 승인/실패/콜백과 최종 판매 확정 흐름은 아직 별도 구현 대상이다.
 
@@ -130,22 +130,29 @@ Ticket은 공연/전시 티켓팅 백엔드다. 현재 구현의 중심은 아�
 
 ### 대기열
 
-대기열 런타임은 `ticket-queue` 독립 서비스가 담당한다. `ticket-be`는 Queue Controller, queue token 저장소, queue token 만료 핸들러를 갖지 않는다. 대신 `PerformanceQueuePolicy`로 공연 상세 응답의 회차별 `entryType`을 계산하고, 클라이언트가 예매 버튼 클릭 시 DIRECT/QUEUE를 분기한다. Queue Server hot path는 Core DB를 조회하지 않으며, 내부 API로 받은 회차별 정책 snapshot을 Queue Redis에서 읽는다.
+대기열 런타임은 `ticket-queue` 독립 서비스가 담당한다. `ticket-be`는 Queue Controller, queue token 저장소, queue token 만료 핸들러를 갖지 않는다. 대신 `PerformanceQueuePolicy`로 공연 상세 응답의 회차별 `entryType`을 계산하고, 클라이언트가 예매 버튼 클릭 시 DIRECT/QUEUE를 분기한다.
+
+Queue Server hot path는 Core DB와 회차별 정책 snapshot을 조회하지 않는다. Queue Server는 모든 요청 회차에 애플리케이션 기본 입장 속도와 TTL을 적용하며, `join`에서 받은 `shardId`와 `localSeq`를 public `/state` 응답의 `serving[shardId]`와 비교해 입장 가능 여부를 판단한다.
+Core의 admission 검증은 `memberId`, `performanceId`뿐 아니라 Queue가 넣은 `queueId` claim도 읽는다. QUEUE 흐름에서 주문 생성(호환용 hold endpoint 포함)이 성공하면 Queue Server의 내부 완료 API를 비동기로 호출해 active session을 조기 반환한다. 이 알림은 선택 기능이며 실패해도 주문을 되돌리지 않고 Queue의 shopping session TTL에 정리를 맡긴다.
+
 
 주요 개념:
 
-- queue session
-- waiting/active 상태
-- adaptive polling
+- 서명된 queue token (`X-Queue-Token`)
+- shard/local sequence와 public state
+- public state 기반 adaptive polling
 - admission token
-- redirectUrl
+- admission token으로 보호 API 진입
 - show detail entryType
 
 주요 위치:
 
-- `C:\Users\mn040\IdeaProjects\ticket-queue`
+- 형제 저장소 `../ticket-queue`
 - `core/core-api/src/main/java/com/ticket/core/config/admission/AdmissionTokenValidator.java`
-- `support/security/src/main/java/com/ticket/support/security/admission`
+- `core/core-api/src/main/java/com/ticket/core/config/admission/QueueSessionCompletionNotifier.java`
+- `core/core-api/src/main/java/com/ticket/core/config/admission/TicketQueueCompletionProperties.java`
+- 형제 저장소 `../ticket-queue`의 내부 session 완료 API
+- `core/core-api/src/main/java/com/ticket/core/config/admission/AdmissionTokenService.java`
 
 ## 핵심 도메인 모델
 
@@ -171,7 +178,7 @@ Ticket은 공연/전시 티켓팅 백엔드다. 현재 구현의 중심은 아�
 ### Queue
 
 - 대기열 상태는 `ticket-queue`가 관리한다.
-- `ticket-be`는 예매 API 진입 시 회차 정책을 먼저 확인하고, 대기열이 필요한 회차에서만 `X-Admission-Token`의 서명, 만료, performanceId 일치 여부를 검증한다.
+- `ticket-be`는 예매 API 진입 시 회차 정책을 먼저 확인하고, 대기열이 필요한 회차에서만 `X-Admission-Token`의 서명, 만료, memberId와 performanceId 일치 여부를 검증한다.
 - `ticket-be`의 Redis는 좌석 선택, hold, refresh token, OAuth2 one-time auth code 용도로만 사용한다.
 
 ## 미구현 또는 후속 범위

--- a/docs/load-test.md
+++ b/docs/load-test.md
@@ -2,6 +2,8 @@
 
 이 문서는 부하 테스트 문서의 진입점이다.
 
+현재 Gatling 소스와 실행 기준은 형제 저장소 `../gatling-test`에 있다. 이 저장소의 `load-tests/gatling`은 이전 API 계약을 사용하는 보관본이므로 새 부하 테스트에 사용하지 않는다.
+
 ## 목적
 
 로컬 환경에서 예매 오픈 순간의 핵심 위험을 재현한다.
@@ -32,7 +34,7 @@
 ```powershell
 .\gradlew.bat :core:core-api:bootRun
 .\gradlew.bat :core:core-api:test --tests "com.ticket.core.config.seed.SeedDataLoaderTest"
-.\gradlew.bat -p load-tests/gatling test
+cd ..\gatling-test
 .\gradlew.bat -p load-tests/gatling gatlingClasses
 ```
 
@@ -40,12 +42,12 @@
 
 대기열 스케줄러 방출량은 Queue Server 처리량이 아니라 Ticket Server가 안정적으로 처리하는 입장 사용자 수를 기준으로 잡는다.
 
-1. `TicketServerCapacitySimulation`으로 Ticket Server 단독 처리량을 측정한다.
+1. `CoreAdmissionCapacitySimulation`을 단계별로 실행해 Ticket Server 단독 처리량을 측정한다.
 2. 실패율, p95/p99, DB connection pool, Redis latency, JVM CPU/GC를 함께 본다.
 3. 안정 구간의 `admitted users/sec` 또는 요청 TPS에 0.6~0.7 안전계수를 적용한다.
-4. Queue Scheduler는 이 값보다 낮은 `admit per tick`으로 방출하도록 설정한다.
+4. Queue Scheduler의 `app.queue.default-max-admit-per-second`를 이 값보다 낮게 설정한다.
 
-현재 Queue Scheduler는 tick마다 `QUEUE_ADMIT_LIMIT_PER_TICK`명씩 waiting 앞쪽 사용자를 active로 승격한다. `QUEUE_ACTIVE_TTL`은 active member TTL이자 admission token 만료 시간으로, Ticket Server 예매 API 사용 가능 시간을 의미한다.
+현재 Queue Scheduler는 shard별 closed slot의 `servingSeq`를 전진시키며, 초당 최대 입장 수는 `app.queue.default-max-admit-per-second`로 제한한다. `app.queue.shopping-session-ttl`은 active session과 admission token의 유효 시간이다.
 
 ## 주의점
 

--- a/docs/load-test/ticket-open-local.md
+++ b/docs/load-test/ticket-open-local.md
@@ -1,8 +1,10 @@
 # 예매 오픈 로컬 부하 테스트
 
-기준일: 2026-06-19
+기준일: 2026-07-30
 
 이 문서는 Gateway 제거 후 구조 기준이다. 부하 테스트는 목적에 따라 Ticket Server와 Queue Server를 직접 호출한다. Queue 흐름은 `join -> public state polling -> enter -> admission token -> Ticket Server 보호 API` 순서다.
+
+현재 Gatling 소스와 상세 옵션의 기준은 형제 저장소 `../../gatling-test`의 `README.md`와 `console/README.md`다. 이 저장소의 `load-tests/gatling`은 이전 API 계약을 사용하는 보관본이다.
 
 ## 목적
 
@@ -10,7 +12,7 @@
 
 - Ticket Server의 admission token 기반 좌석/주문 처리량
 - Queue Server의 join/enter 처리량
-- Queue public state polling과 admitted sequence 기준 입장
+- Queue public state polling과 shard별 serving sequence 기준 입장
 - 같은 좌석 hold/order 경합
 
 운영 환경에 직접 부하를 주지 않는다. 운영과 가까운 처리량은 별도 스테이징 환경에서 같은 시나리오로 확인한다.
@@ -42,19 +44,24 @@ docker run --name ticket-queue-redis -p 6380:6379 -d redis:7
 Ticket Server:
 
 ```powershell
-cd C:\Users\mn040\IdeaProjects\ticket-workspace\ticket
+# ticket 저장소 루트에서 실행
 $env:SPRING_PROFILES_ACTIVE="local"
 $env:JWT_SECRET="same-access-token-secret-32bytes-minimum"
 $env:JWT_ACCESS_TOKEN_EXPIRATION_SECONDS="1800"
 $env:JWT_REFRESH_TOKEN_EXPIRATION_SECONDS="1209600"
 $env:ADMISSION_TOKEN_SECRET_KEY="same-admission-secret-32bytes-minimum"
+$env:GOOGLE_CLIENT_ID="local-google-client-id"
+$env:GOOGLE_CLIENT_SECRET="local-google-client-secret"
+$env:KAKAO_CLIENT_ID="local-kakao-client-id"
+$env:KAKAO_CLIENT_SECRET="local-kakao-client-secret"
+$env:KAKAO_ADMIN_KEY="local-kakao-admin-key"
 .\gradlew.bat :core:core-api:bootRun
 ```
 
 Queue Server:
 
 ```powershell
-cd C:\Users\mn040\IdeaProjects\ticket-workspace\ticket-queue
+# ticket-queue 저장소 루트에서 실행
 $env:SPRING_DATA_REDIS_PORT="6380"
 $env:JWT_SECRET="same-access-token-secret-32bytes-minimum"
 $env:JWT_ISSUER="ticket"
@@ -73,11 +80,11 @@ $env:QUEUE_TOKEN_SECRET="same-queue-token-secret-32bytes-minimum"
 2. Queue 회차
    POST http://localhost:8090/api/v1/queue/performances/{performanceId}/join
    Authorization: Bearer {accessToken}
-   -> seq, queueToken 저장
+   -> shardId, localSeq, queueToken 저장
 
 3. Queue public state polling
    GET http://localhost:8090/api/v1/queue/performances/{performanceId}/state
-   -> admittedUntilSeq >= seq 이면 enter 가능
+   -> serving[shardId] >= localSeq 이면 enter 가능
 
 4. Queue enter
    POST http://localhost:8090/api/v1/queue/performances/{performanceId}/enter
@@ -93,7 +100,9 @@ $env:QUEUE_TOKEN_SECRET="same-queue-token-secret-32bytes-minimum"
 
 ## Gatling 실행
 
-Gatling은 루트 Gradle wrapper로 `load-tests/gatling` 독립 프로젝트를 실행한다.
+Gatling은 형제 `gatling-test` 저장소의 Gradle wrapper와 `load-tests/gatling` 프로젝트를 사용한다.
+
+아래 명령은 `gatling-test` 저장소 루트에서 실행한다. 실행 전 대상 URL, 사용자 수, 전용 `performanceId`, feeder를 확인한다.
 
 공통 옵션:
 
@@ -142,20 +151,19 @@ Gatling은 루트 Gradle wrapper로 `load-tests/gatling` 독립 프로젝트를 
 
 ### 2. Ticket Server 단독 용량
 
-Queue Server를 거치지 않고 Ticket Server에 `Authorization`과 `X-Admission-Token`을 직접 붙여 보호 API 처리량을 측정한다.
+Queue Server를 거치지 않고 Ticket Server에 `Authorization`과 `X-Admission-Token`을 직접 붙여 보호 API 처리량을 측정한다. 회원·좌석·토큰 조합은 현재 표준인 booking feeder CSV로 공급한다.
 
 ```powershell
 .\gradlew.bat -p load-tests/gatling gatlingRun `
-  --simulation com.ticket.loadtest.simulation.TicketServerCapacitySimulation `
-  -DbaseUrl=http://localhost:8080 `
+  --simulation com.ticket.loadtest.simulation.CoreAdmissionCapacitySimulation `
+  -DcoreBaseUrl=http://localhost:8080 `
   -DperformanceId=1 `
-  -DseatIds=1,2,3,4,5 `
-  -Dusers=5 `
-  -DdurationSeconds=10 `
-  -DaccessTokenMode=synthetic-jwt `
-  -DjwtSecret=same-access-token-secret-32bytes-minimum `
-  -DadmissionTokenMode=synthetic `
-  -DadmissionTokenSecret=same-admission-secret-32bytes-minimum
+  -DbookingFeederFile=C:\path\booking-feeder.csv `
+  -DbookingScenario=CORE_ADMISSION_CAPACITY `
+  -DinjectionMode=constant-users-per-sec `
+  -DusersPerSecond=10 `
+  -DdurationSeconds=60 `
+  -DresultFile=build\reports\core-capacity-local.csv
 ```
 
 확인할 것:
@@ -168,41 +176,41 @@ Queue Server를 거치지 않고 Ticket Server에 `Authorization`과 `X-Admissio
 
 ### 3. 예매 오픈 전체 흐름
 
-`TicketOpenFlowSimulation`은 Queue Server에서 `join` 후 public state를 polling하고, admitted sequence에 도달하면 `X-Queue-Token`으로 `enter`를 호출한다. `admissionToken`을 받은 사용자만 Ticket Server 좌석 상태 조회와 주문 생성을 시도한다.
+`TicketOpenEndToEndSimulation`은 Queue Server에서 `join` 후 public state를 polling하고, 자신의 shard에서 serving sequence에 도달하면 `X-Queue-Token`으로 `enter`를 호출한다. `admissionToken`을 받은 사용자만 Ticket Server 좌석 상태 조회와 주문 생성을 시도한다.
 
 ```powershell
 .\gradlew.bat -p load-tests/gatling gatlingRun `
-  --simulation com.ticket.loadtest.simulation.TicketOpenFlowSimulation `
+  --simulation com.ticket.loadtest.simulation.TicketOpenEndToEndSimulation `
   -DcoreBaseUrl=http://localhost:8080 `
   -DqueueBaseUrl=http://localhost:8090 `
   -DperformanceId=1 `
-  -DseatIds=1 `
-  -Dusers=10 `
-  -DdurationSeconds=10 `
+  -DbookingFeederFile=C:\path\booking-feeder.csv `
+  -DbookingScenario=TICKET_OPEN_END_TO_END `
+  -DinjectionMode=constant-users-per-sec `
+  -DusersPerSecond=10 `
+  -DdurationSeconds=60 `
   -DstatusPolls=3 `
   -DstatusPollPauseSeconds=1 `
-  -DaccessTokenMode=synthetic-jwt `
-  -DjwtSecret=same-access-token-secret-32bytes-minimum
+  -DresultFile=build\reports\ticket-open-local.csv
 ```
 
 주의: 이 시나리오는 `coreBaseUrl`과 `queueBaseUrl`을 분리해 사용한다. 둘 중 하나를 생략하면 해당 값은 `baseUrl`로 대체된다.
 
-### 4. Admission Token 직접 입력
+### 4. 좌석 경합
 
-Ticket Server 단독 테스트에 Queue Server가 발급한 admission token을 직접 넣으려면 `admissionTokenMode=tokens`를 사용한다. admission token은 요청 대상과 같은 `performanceId`여야 하며, subject는 access token의 회원과 일치해야 한다.
+같은 좌석에 여러 회원을 집중시켜 hold/order 정합성을 확인한다. feeder의 여러 행에 같은 `seatId`를 넣고, 각 행에는 서로 다른 회원의 access token과 그 회원·공연에 바인딩된 admission token을 넣는다.
 
 ```powershell
 .\gradlew.bat -p load-tests/gatling gatlingRun `
-  --simulation com.ticket.loadtest.simulation.HoldRaceSimulation `
-  -DbaseUrl=http://localhost:8080 `
+  --simulation com.ticket.loadtest.simulation.SeatContentionSimulation `
+  -DcoreBaseUrl=http://localhost:8080 `
   -DperformanceId=1 `
-  -DseatIds=1 `
-  -DaccessTokenMode=tokens `
-  -DaccessTokens=$accessTokenList `
-  -DadmissionTokenMode=tokens `
-  -DadmissionTokens=$admissionTokenList `
+  -DbookingFeederFile=C:\path\seat-contention-feeder.csv `
+  -DbookingScenario=SEAT_CONTENTION `
+  -DinjectionMode=at-once-users `
   -Dusers=10 `
-  -DdurationSeconds=10
+  -DdurationSeconds=10 `
+  -DresultFile=build\reports\seat-contention-local.csv
 ```
 
 ## 완료 기준

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -111,6 +111,26 @@ ADMISSION_TOKEN_ENFORCEMENT_ENABLED=false
 ```
 
 Queue Server와 클라이언트의 admission token 전달이 모두 준비된 뒤에만 `true`로 전환한다. 비활성 상태에서는 회차의 Queue 정책과 admission token을 조회하거나 검증하지 않는다.
+### Queue active session 조기 반환
+
+Core가 주문 생성 성공 후 Queue active session을 즉시 반환하게 하려면 Queue Server의 내부 완료 API와 공유 secret을 먼저 배포한 뒤 아래 값을 설정한다.
+
+```text
+QUEUE_COMPLETION_ENABLED=true
+QUEUE_SERVER_BASE_URL=http://ticket-queue:8090
+QUEUE_COMPLETION_SECRET=<ticket-queue와 같은 32자 이상 secret>
+QUEUE_COMPLETION_CONNECT_TIMEOUT=500ms
+QUEUE_COMPLETION_READ_TIMEOUT=1s
+```
+
+전환 순서는 다음과 같다.
+
+1. Queue Server에 내부 완료 endpoint와 `QUEUE_COMPLETION_SECRET`을 배포한다.
+2. Core에 같은 secret과 Queue 내부 base URL을 설정한다.
+3. Core의 `QUEUE_COMPLETION_ENABLED`를 `true`로 바꾼다.
+
+완료 알림은 주문 응답과 분리된 비동기 best-effort 호출이다. 현재 결제 API가 없으므로 `PENDING` 주문 생성 성공을 예매 흐름의 종료점으로 사용한다. 결제가 추가되면 완료 알림을 결제 성공·실패·취소 같은 최종 상태로 옮긴다. 실패 로그가 발생해도 주문 자체는 성공 상태를 유지하며, Queue의 shopping session TTL이 최종 정리 안전망이다. 이 때문에 콜백 성공률과 TTL 만료 정리량을 함께 관측해야 한다.
+
 
 ## DB 마이그레이션
 
@@ -143,28 +163,71 @@ local 프로파일은 H2 file DB(`~/ticket-local`)를 Hibernate `ddl-auto:create
 
 ## 배포 workflow
 
-GitHub Actions 배포 workflow는 아래 명령과 맞물린다.
+GitHub Actions 배포 workflow는 전체 테스트와 infra 통합 테스트를 통과한 뒤 bootJar를 만든다.
 
 ```bash
-./gradlew clean :core:core-api:bootJar -x test
+./gradlew clean test :core:core-infra:integrationTest :core:core-api:bootJar
 ```
 
 관련 파일:
 
 - `.github/workflows/deploy.yml`
 
+## Core 용량 관측
+
+Core는 `/actuator/prometheus`에서 용량 판정에 필요한 애플리케이션 메트릭을 노출한다. 부하 테스트 중에는 다음을 같은 시간축으로 본다.
+
+- `http_server_requests_seconds_bucket/count`: URI·method·status별 처리량과 p95/p99
+- `hikaricp_connections_active/pending/max/min`: DB connection pool 사용량과 대기
+- `tomcat_threads_busy_threads/current_threads/config_max_threads`: 요청 스레드 사용량과 상한
+- `jvm_gc_pause_seconds`, `jvm_memory_used_bytes`, `process_cpu_usage`: JVM·CPU 포화 여부
+
+모든 메트릭에는 `service`, `environment`, `version` 태그가 붙는다. 운영 task에는 `DD_SERVICE=ticket-core`, `DD_ENV=prod`, `DD_VERSION=<배포버전>`을 동일하게 주입해야 task별 비교와 배포 전후 비교가 가능하다.
+
+```promql
+histogram_quantile(0.99, sum by (le, uri, method) (rate(http_server_requests_seconds_bucket{service="ticket-core"}[1m])))
+```
+
+```promql
+sum(rate(http_server_requests_seconds_count{service="ticket-core",status=~"5.."}[1m]))
+max(hikaricp_connections_pending{service="ticket-core"})
+(
+  max(tomcat_threads_busy_threads{service="ticket-core"})
+  /
+  max(tomcat_threads_config_max_threads{service="ticket-core"})
+)
+```
+
+Hikari pending이 0보다 커지면 애플리케이션 요청이 DB 연결을 빌리지 못하고 기다리는 상태다. 다만 pending이 0이어도 이미 빌린 연결이 DB lock에서 멈출 수 있으므로 DB wait를 별도로 확인해야 한다.
+
+Oracle lock wait는 Actuator만으로 볼 수 없다. Oracle exporter·Datadog DBM 또는 DBA 권한이 있는 별도 관측 계정에서 다음 정보를 수집한다.
+
+```sql
+SELECT COUNT(*) AS blocked_sessions FROM v$session WHERE blocking_session IS NOT NULL;
+
+SELECT event, COUNT(*) AS waiting_sessions, MAX(seconds_in_wait) AS max_seconds_in_wait
+FROM v$session
+WHERE state = 'WAITING' AND wait_class <> 'Idle'
+GROUP BY event
+ORDER BY waiting_sessions DESC;
+```
+
+`v$session` 조회 권한은 애플리케이션 계정에 추가하지 말고 관측 전용 계정에만 부여한다.
+
 ## 부하 테스트
 
 예매 오픈 부하 테스트는 [load-test.md](load-test.md)에서 시작한다.
 
-상세 실행 문서:
+상세 실행 문서와 실제 실행 프로젝트:
 
 - `docs/load-test/ticket-open-local.md`
+- 형제 저장소 `../gatling-test/README.md`
+- 로컬 콘솔 `../gatling-test/console/README.md`
 
-Gatling 프로젝트는 루트 Gradle wrapper로 실행한다.
+현재 Gatling 시나리오는 이 저장소가 아니라 형제 `gatling-test` 저장소에서 관리한다. 이 저장소의 `load-tests/gatling`은 이전 시나리오 보관본이므로 새 부하 테스트에 사용하지 않는다.
 
 ```powershell
-.\gradlew.bat -p load-tests/gatling test
+cd ..\gatling-test
 .\gradlew.bat -p load-tests/gatling gatlingClasses
 ```
 

--- a/docs/superpowers/plans/2026-03-15-performance-queue.md
+++ b/docs/superpowers/plans/2026-03-15-performance-queue.md
@@ -1,6 +1,6 @@
 # Performance Queue Implementation Plan
 
-> 기준 변경: 이 문서는 과거 ticket-be 내장 queue/queueToken 설계 기록이다. 현재 실행 기준은 2026-05-24-separated-queue-server-design.md와 2026-05-24-separated-queue-server.md이다. 새 구조에서는 queueToken/X-Queue-Token 대신 queueSessionId/X-Queue-Session과 admissionToken/X-Admission-Token을 사용한다.
+> 보관 문서: 당시의 구현 계획입니다. 현재 동작과 명령은 저장소 루트 `README.md`, `docs/development.md`, 형제 저장소 `../ticket-queue/README.md`, `../gatling-test/README.md`를 기준으로 확인하세요. 이 문서의 queue token/session/status 모델은 현재의 shard/local sequence/public state 구조와 다를 수 있습니다.
 
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-03-17-member-bound-queue.md
+++ b/docs/superpowers/plans/2026-03-17-member-bound-queue.md
@@ -1,6 +1,6 @@
 # Member-Bound Queue Implementation Plan
 
-> 기준 변경: 이 문서는 과거 ticket-be 내장 queue/queueToken 설계 기록이다. 현재 실행 기준은 2026-05-24-separated-queue-server-design.md와 2026-05-24-separated-queue-server.md이다. 새 구조에서는 queueToken/X-Queue-Token 대신 queueSessionId/X-Queue-Session과 admissionToken/X-Admission-Token을 사용한다.
+> 보관 문서: 당시의 구현 계획입니다. 현재 동작과 명령은 저장소 루트 `README.md`, `docs/development.md`, 형제 저장소 `../ticket-queue/README.md`, `../gatling-test/README.md`를 기준으로 확인하세요. 이 문서의 queue token/session/status 모델은 현재의 shard/local sequence/public state 구조와 다를 수 있습니다.
 
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-05-09-ticket-open-load-test.md
+++ b/docs/superpowers/plans/2026-05-09-ticket-open-load-test.md
@@ -1,6 +1,6 @@
 # Ticket Open Load Test Implementation Plan
 
-> 기준 변경: 이 문서는 과거 ticket-be 내장 queue/queueToken 설계 기록이다. 현재 실행 기준은 2026-05-24-separated-queue-server-design.md와 2026-05-24-separated-queue-server.md이다. 새 구조에서는 queueToken/X-Queue-Token 대신 queueSessionId/X-Queue-Session과 admissionToken/X-Admission-Token을 사용한다.
+> 보관 문서: 당시의 구현 계획입니다. 현재 부하 테스트 기준은 형제 저장소 `../gatling-test/README.md`이며, 서버 계약은 루트 `README.md`와 `docs/development.md`를 기준으로 확인하세요. 이 문서의 내장 Gatling 및 queue token/session/status 설명은 현재 구조와 다를 수 있습니다.
 
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-05-24-separated-queue-server.md
+++ b/docs/superpowers/plans/2026-05-24-separated-queue-server.md
@@ -2,7 +2,7 @@
 
 기준일: 2026-05-24
 
-이 문서는 현재 구현 기준의 확인용 계획이다. 과거 내장 queue token 계획은 더 이상 실행 기준이 아니다.
+> 보관 문서: 분리형 Queue Server 도입 당시의 계획입니다. 이후 Gateway가 제거되고 queueSession/status/waiting-active 모델은 shard/local sequence/public state 모델로 바뀌었습니다. 현재 기준은 루트 `README.md`, `docs/development.md`, 형제 저장소 `../ticket-queue/README.md`입니다.
 
 ## 목표
 
@@ -88,7 +88,7 @@ ticket-queue
 Ticket Server:
 
 ```powershell
-cd C:\Users\mn040\IdeaProjects\ticket-workspace\ticket
+cd ticket  # workspace 루트에서 실행
 .\gradlew.bat :core:core-domain:test
 .\gradlew.bat :core:core-api:test
 .\gradlew.bat :core:core-api:bootJar -x test
@@ -97,23 +97,21 @@ cd C:\Users\mn040\IdeaProjects\ticket-workspace\ticket
 Queue Server:
 
 ```powershell
-cd C:\Users\mn040\IdeaProjects\ticket-workspace\ticket-queue
+cd ticket-queue  # workspace 루트에서 실행
 .\gradlew.bat test
 .\gradlew.bat bootJar
 ```
 
-Gateway:
+Gateway(당시 저장소, 현재 제거됨):
 
 ```powershell
-cd C:\Users\mn040\IdeaProjects\ticket-workspace\ticket-gateway
-.\gradlew.bat test
-.\gradlew.bat bootJar -x test
+# 현재 검증 대상이 아님
 ```
 
 Frontend:
 
 ```powershell
-cd C:\Users\mn040\IdeaProjects\ticket-workspace\ticket-fe
+cd ticket-fe  # workspace 루트에서 실행
 pnpm build
 ```
 

--- a/docs/superpowers/plans/2026-06-17-gateway-removal.md
+++ b/docs/superpowers/plans/2026-06-17-gateway-removal.md
@@ -1,5 +1,7 @@
 # Gateway Removal Implementation Plan
 
+> 결정 기록: Gateway 제거 작업 당시의 구현 계획입니다. 현재 실행 방법과 서비스 계약은 루트 `README.md`, `docs/development.md`, 형제 저장소 `../ticket-queue/README.md`를 기준으로 확인하세요.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Remove the runtime dependency on `ticket-gateway` by letting core and queue validate external access tokens directly and by binding queue/admission tokens to the authenticated member.

--- a/docs/superpowers/specs/2026-03-15-performance-queue-design.md
+++ b/docs/superpowers/specs/2026-03-15-performance-queue-design.md
@@ -1,6 +1,6 @@
 # Performance Queue Design
 
-> 기준 변경: 이 문서는 과거 ticket-be 내장 queue/queueToken 설계 기록이다. 현재 실행 기준은 2026-05-24-separated-queue-server-design.md와 2026-05-24-separated-queue-server.md이다. 새 구조에서는 queueToken/X-Queue-Token 대신 queueSessionId/X-Queue-Session과 admissionToken/X-Admission-Token을 사용한다.
+> 보관 문서: 당시의 설계 기록입니다. 현재 동작과 명령은 저장소 루트 `README.md`, `docs/development.md`, 형제 저장소 `../ticket-queue/README.md`, `../gatling-test/README.md`를 기준으로 확인하세요. 이 문서의 queue token/session/status 모델은 현재의 shard/local sequence/public state 구조와 다를 수 있습니다.
 
 
 **목표**

--- a/docs/superpowers/specs/2026-03-17-member-bound-queue-design.md
+++ b/docs/superpowers/specs/2026-03-17-member-bound-queue-design.md
@@ -1,6 +1,6 @@
 # Member-Bound Queue Design
 
-> 기준 변경: 이 문서는 과거 ticket-be 내장 queue/queueToken 설계 기록이다. 현재 실행 기준은 2026-05-24-separated-queue-server-design.md와 2026-05-24-separated-queue-server.md이다. 새 구조에서는 queueToken/X-Queue-Token 대신 queueSessionId/X-Queue-Session과 admissionToken/X-Admission-Token을 사용한다.
+> 보관 문서: 당시의 설계 기록입니다. 현재 동작과 명령은 저장소 루트 `README.md`, `docs/development.md`, 형제 저장소 `../ticket-queue/README.md`, `../gatling-test/README.md`를 기준으로 확인하세요. 이 문서의 queue token/session/status 모델은 현재의 shard/local sequence/public state 구조와 다를 수 있습니다.
 
 
 **목표**

--- a/docs/superpowers/specs/2026-04-01-datadog-docker-compose-design.md
+++ b/docs/superpowers/specs/2026-04-01-datadog-docker-compose-design.md
@@ -1,5 +1,7 @@
 # Datadog Docker Compose Design
 
+> 보관 문서: Datadog 도입 당시의 설계 기록입니다. 파일 링크는 현재 저장소 위치로 정리했지만, 본문의 배포 구성과 의존성 상태는 당시 기준이므로 현재 운영 절차는 `docs/operations.md`를 우선하세요.
+
 ## 목표
 
 `oneticket.site` 운영 서버의 Docker Compose 환경에 Datadog을 도입해 아래 항목을 한 번에 관측 가능하게 만든다.
@@ -12,10 +14,10 @@
 ## 현재 구조
 
 - 애플리케이션은 Ubuntu 서버에서 `docker compose`로 배포된다.
-- 저장소의 [docker-compose.yml](C:\Users\mn040\IdeaProjects\ticket\docker-compose.yml)은 로컬 Redis만 포함하고, 실제 운영 배포는 GitHub Actions가 서버의 `/home/ubuntu/docker-compose.yml`을 사용한다.
-- [Dockerfile](C:\Users\mn040\IdeaProjects\ticket\Dockerfile)은 Spring Boot fat jar만 복사해 실행한다.
-- [logback-prod.xml](C:\Users\mn040\IdeaProjects\ticket\support\logging\src\main\resources\logback\logback-prod.xml)은 stdout 로그를 사용하고 `traceId`, `spanId` MDC 자리를 이미 포함한다.
-- [core-api/build.gradle](C:\Users\mn040\IdeaProjects\ticket\core\core-api\build.gradle)에는 아직 Actuator/Prometheus 의존성이 없다.
+- 당시 저장소의 `docker-compose.yml`은 로컬 Redis만 포함했고, 실제 운영 배포는 GitHub Actions가 서버의 `/home/ubuntu/docker-compose.yml`을 사용했다. 해당 로컬 Compose 파일은 현재 저장소에는 없다.
+- [Dockerfile](../../../Dockerfile)은 Spring Boot fat jar만 복사해 실행한다.
+- [logback-prod.xml](../../../support/logging/src/main/resources/logback/logback-prod.xml)은 stdout 로그를 사용하고 `traceId`, `spanId` MDC 자리를 이미 포함한다.
+- [core-api/build.gradle](../../../core/core-api/build.gradle)에는 당시 Actuator/Prometheus 의존성이 없었다.
 
 ## 설계
 
@@ -39,13 +41,13 @@
 
 ## 코드 변경 범위
 
-- [core/core-api/build.gradle](C:\Users\mn040\IdeaProjects\ticket\core\core-api\build.gradle)
+- [core/core-api/build.gradle](../../../core/core-api/build.gradle)
   - Actuator/Prometheus 의존성 추가
-- [core/core-api/src/main/resources/application.yml](C:\Users\mn040\IdeaProjects\ticket\core\core-api\src\main\resources\application.yml)
+- [core/core-api/src/main/resources/application.yml](../../../core/core-api/src/main/resources/application.yml)
   - `health`, `info`, `prometheus` endpoint 노출
-- [core/core-api/src/main/java/com/ticket/core/config/security/SecurityConfig.java](C:\Users\mn040\IdeaProjects\ticket\core\core-api\src\main\java\com\ticket\core\config\security\SecurityConfig.java)
+- [core/core-api/src/main/java/com/ticket/core/config/security/SecurityConfig.java](../../../core/core-api/src/main/java/com/ticket/core/config/security/SecurityConfig.java)
   - actuator endpoint 허용
-- [Dockerfile](C:\Users\mn040\IdeaProjects\ticket\Dockerfile)
+- [Dockerfile](../../../Dockerfile)
   - `dd-java-agent.jar` 포함
 
 ## 운영 변경 범위

--- a/docs/superpowers/specs/2026-05-09-ticket-open-load-test-design.md
+++ b/docs/superpowers/specs/2026-05-09-ticket-open-load-test-design.md
@@ -1,6 +1,6 @@
 # Ticket Open Load Test Design
 
-> 기준 변경: 이 문서는 과거 ticket-be 내장 queue/queueToken 설계 기록이다. 현재 실행 기준은 2026-05-24-separated-queue-server-design.md와 2026-05-24-separated-queue-server.md이다. 새 구조에서는 queueToken/X-Queue-Token 대신 queueSessionId/X-Queue-Session과 admissionToken/X-Admission-Token을 사용한다.
+> 보관 문서: 당시의 설계 기록입니다. 현재 부하 테스트 기준은 형제 저장소 `../gatling-test/README.md`이며, 서버 계약은 루트 `README.md`와 `docs/development.md`를 기준으로 확인하세요. 이 문서의 내장 Gatling 및 queue token/session/status 설명은 현재 구조와 다를 수 있습니다.
 
 
 **목표**

--- a/docs/superpowers/specs/2026-05-24-separated-queue-server-design.md
+++ b/docs/superpowers/specs/2026-05-24-separated-queue-server-design.md
@@ -1,5 +1,7 @@
 # Separated Queue Server Design
 
+> 보관 문서: 분리형 Queue Server 도입 당시의 설계입니다. 이후 Gateway가 제거되고 queueSession/status/waiting-active 모델은 shard/local sequence/public state 모델로 바뀌었습니다. 현재 기준은 루트 `README.md`, `docs/development.md`, 형제 저장소 `../ticket-queue/README.md`입니다.
+
 **목표**
 
 - 대기열 서버와 티켓 서버를 분리한다.
@@ -131,7 +133,7 @@ Gateway는 `Authorization`, `X-Queue-Session`, `X-Admission-Token` 헤더를 보
 확정 구현은 기존 `ticket` 저장소 내부 모듈이 아니라 별도 폴더의 독립 Queue Server 프로젝트를 기준으로 한다. Queue Server는 현재 멀티모듈이 아니라 단일 Spring Boot/Gradle 프로젝트로 유지한다.
 
 ```text
-C:\Users\mn040\IdeaProjects\ticket-workspace\ticket-queue
+ticket-queue/
 ├── src/main/java/com/ticket/queue
 │   ├── api             # enter/status HTTP API와 응답 DTO
 │   ├── application     # use case, status 조회, scheduler, admission 응답 조립
@@ -165,7 +167,7 @@ Queue 관련 런타임 코드는 `ticket-queue`로 분리한다. Queue Server는
 
 ```text
 1단계: Ticket Server support:security admission token 검증 유지
-2단계: C:\Users\mn040\IdeaProjects\ticket-workspace\ticket-queue 독립 프로젝트 생성
+2단계: workspace의 `ticket-queue/` 독립 프로젝트 생성
 3단계: Queue Server를 단일 Spring Boot 프로젝트로 구성
 4단계: core-api에서 queue controller 제거 또는 Gateway route에서 제외
 5단계: core-api에는 회차 정책 기반 admission gate만 유지
@@ -471,7 +473,7 @@ X-Admission-Token: {admissionToken}
 
 ### 2단계: Queue Server 분리
 
-- `C:\Users\mn040\IdeaProjects\ticket-queue` 독립 프로젝트 추가
+- workspace에 `ticket-queue/` 독립 프로젝트 추가
 - 단일 Spring Boot/Gradle 프로젝트로 api/application/domain/infra/config 패키지 구성
 - queue enter/status controller 구성 후 기존 core-api queue endpoint 비활성화
 - Queue Server 인증 filter 제거

--- a/docs/superpowers/specs/2026-06-17-gateway-removal-design.md
+++ b/docs/superpowers/specs/2026-06-17-gateway-removal-design.md
@@ -2,6 +2,8 @@
 
 기준일: 2026-06-17
 
+> 결정 기록: Gateway 제거 당시의 설계입니다. 현재 실행 방법과 서비스 계약은 루트 `README.md`, `docs/development.md`, 형제 저장소 `../ticket-queue/README.md`를 기준으로 확인하세요.
+
 > 2026-06-17 후속 결정: `Passport`와 `ticket-common`도 제거한다. core는 `MemberPrincipal`, queue는 `AuthenticatedMember`를 서비스 로컬 principal로 사용하며, access/admission token 발급·검증 코드는 각 서비스가 직접 소유한다. 아래 본문 중 `Passport`/`ticket-common` 유지 내용은 이 후속 결정으로 대체된다.
 
 ## 목표

--- a/tools/seed-kopis/README.md
+++ b/tools/seed-kopis/README.md
@@ -3,7 +3,6 @@
 KOPIS OpenAPI에서 신규 공연을 가져와 `core/core-api/src/main/resources/seed/kopis-curated.sql`에 **누적 추가**한다.
 기존 시드(SHOWS 1~292 등)는 건드리지 않고, 다음 id부터 이어 붙인다.
 
-설계 문서: `docs/superpowers/specs/2026-06-06-kopis-data-refresh-design.md`
 
 ## 사전 준비
 
@@ -48,10 +47,14 @@ $env:KOPIS_SERVICE_KEY="xxxx"; node tools/seed-kopis/fetch-kopis.mjs --target 10
 
 ## 병합 후 검증
 
+ticket 저장소 루트에서 적재 무결성 테스트를 실행한다.
+
+```powershell
+.\gradlew.bat :core:core-api:test
+```
+
 ```bash
-# 적재 무결성 (시드 켜고 기동하거나 테스트)
-cd ..  # ticket 루트
-./gradlew.bat :core:core-api:test
+./gradlew :core:core-api:test
 ```
 
 문제가 있으면 `kopis-curated.sql.bak`으로 복원한다.


### PR DESCRIPTION
## 변경 내용
- 현재 5개 Gradle 모듈과 분리된 Queue Server 경계를 기준으로 README·아키텍처·개발·운영 문서를 정리했습니다.
- 오래된 queue session/status 및 내장 Gatling 예시를 shard/local sequence/public state와 별도 `gatling-test` 저장소 기준으로 교체했습니다.
- 과거 구현 계획은 현재 실행 기준과 혼동되지 않도록 보관 문서로 표시하고, 개인 PC 절대경로와 깨진 링크를 제거했습니다.
- Queue active session 조기 반환 설정과 안전한 전환 순서를 문서화했습니다.

## 변경 이유
현재 문서와 과거 설계 기록이 섞여 있어 제거된 모듈·API·시뮬레이션을 현재 실행 방법으로 오해할 수 있었습니다. 현재 소스 구조와 운영 workflow를 기준으로 문서의 기준점을 다시 맞췄습니다.

## 영향
문서만 변경하며 런타임 코드와 설정은 포함하지 않습니다.

## 검증
- GitHub compare에서 변경 파일 19개가 모두 Markdown임을 확인
- `git diff --check`
- UTF-8 BOM, 상대 링크, Markdown 코드 펜스 정적 검사
- 문서에 적힌 Gatling simulation 클래스 존재 여부 검사

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 부하 테스트 기준과 실행 절차를 최신화하고, 관련 시나리오 및 명령 안내를 정비했습니다.
  * 예매 오픈, Queue 흐름, active session 조기 반환 및 용량 관측 지표 설명을 보강했습니다.
  * 로컬 실행을 위한 OAuth2·Queue 환경변수와 운영 배포 전환 절차를 추가했습니다.
  * 오래된 설계·계획 문서에는 보관 문서임을 표시하고 최신 참고 문서를 안내합니다.
  * 모듈 구조, Redis 운영 방식, 테스트 도구 실행 안내와 문서 기준일을 갱신했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->