### PR TITLE
feat(core-api): expose Core capacity observability metrics

### DIFF
--- a/core/core-api/src/main/resources/application.yml
+++ b/core/core-api/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  application:
+    name: ticket-core
+  datasource:
+    hikari:
+      pool-name: ticket-core
   config:
     import:
       - logging.yml
@@ -49,6 +54,9 @@ spring:
 
 server:
   forward-headers-strategy: framework
+  tomcat:
+    mbeanregistry:
+      enabled: true
 
 management:
   endpoints:
@@ -59,6 +67,20 @@ management:
     health:
       probes:
         enabled: true
+  metrics:
+    tags:
+      service: ${DD_SERVICE:ticket-core}
+      environment: ${DD_ENV:local}
+      version: ${DD_VERSION:unknown}
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      slo:
+        http.server.requests: 100ms,300ms,500ms,1s,2s,3s,5s
+      minimum-expected-value:
+        http.server.requests: 1ms
+      maximum-expected-value:
+        http.server.requests: 10s
 
 springdoc:
   use-fqn: true

--- a/core/core-api/src/test/java/com/ticket/core/config/ObservabilityConfigurationTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/config/ObservabilityConfigurationTest.java
@@ -1,0 +1,37 @@
+package com.ticket.core.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.ClassPathResource;
+
+import java.util.Objects;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObservabilityConfigurationTest {
+
+    @Test
+    void exposesCapacityMetricsWithStableTagsAndHistograms() {
+        final YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean();
+        yaml.setResources(new ClassPathResource("application.yml"));
+        final Properties properties = Objects.requireNonNull(yaml.getObject());
+
+        assertThat(properties)
+                .containsEntry("spring.application.name", "ticket-core")
+                .containsEntry("spring.datasource.hikari.pool-name", "ticket-core")
+                .containsEntry("server.tomcat.mbeanregistry.enabled", true)
+                .containsEntry("management.endpoints.web.exposure.include", "health,info,prometheus")
+                .containsEntry("management.metrics.tags.service", "${DD_SERVICE:ticket-core}")
+                .containsEntry("management.metrics.tags.environment", "${DD_ENV:local}")
+                .containsEntry("management.metrics.tags.version", "${DD_VERSION:unknown}")
+                .containsEntry(
+                        "management.metrics.distribution.percentiles-histogram.http.server.requests",
+                        true
+                )
+                .containsEntry(
+                        "management.metrics.distribution.slo.http.server.requests",
+                        "100ms,300ms,500ms,1s,2s,3s,5s"
+                );
+    }
+}


### PR DESCRIPTION
## 변경 내용

- HTTP 요청 histogram과 용량 판정용 SLO bucket을 활성화했습니다.
- HikariCP pool 이름과 Tomcat MBean registry를 설정했습니다.
- `service`, `environment`, `version` 공통 메트릭 태그를 추가했습니다.
- 설정 회귀 테스트를 추가했으며, PromQL·Oracle wait 운영 문서는 최신 `master`에 이미 반영되어 있습니다.

## 왜 필요한가

Gatling에서 p95/p99가 증가한 사실만으로는 DB connection 대기, Tomcat thread 포화, JVM 부하 중 원인을 구분할 수 없습니다. Core 안전 입장률을 결정할 때 애플리케이션 처리량과 내부 포화 지표를 같은 시간축으로 확인하기 위한 변경입니다.

## 영향 범위

- 관측 설정과 문서만 변경합니다.
- Queue 입장 제어, admission token, 주문 처리 동작은 변경하지 않습니다.

## 검증

- `.\gradlew.bat test :core:core-api:bootJar --no-daemon`
- 전체 테스트 및 bootJar 생성 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 애플리케이션 및 데이터베이스 커넥션 풀 식별 정보를 추가했습니다.
  * HTTP 요청 처리 시간의 백분위수와 SLO 기반 메트릭을 제공합니다.
  * 서비스, 환경, 버전 정보를 포함한 Datadog 메트릭 태그를 지원합니다.
  * Tomcat 및 애플리케이션 메트릭 관측 기능을 활성화했습니다.

* **문서**
  * 부하 테스트 시 확인할 주요 메트릭과 PromQL 예시를 추가했습니다.
  * 데이터베이스 연결 대기 및 Oracle 잠금 대기 관측 방법을 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->