### PR TITLE
refactor: 공연 대기열 정책 단순화 및 좌석 접근 검증 보강

### DIFF
--- a/core/core-api/src/test/java/com/ticket/core/config/admission/AdmissionTokenValidatorTest.java
+++ b/core/core-api/src/test/java/com/ticket/core/config/admission/AdmissionTokenValidatorTest.java
@@ -109,7 +109,7 @@ class AdmissionTokenValidatorTest {
                 2,
                 600
         );
-        performance.updateQueuePolicy(queueMode, null, null, null, now.minusMinutes(5), null, null);
+        performance.updateQueuePolicy(queueMode, null, now.minusMinutes(5), null, null);
         return performance;
     }
 }

--- a/core/core-domain/src/main/java/com/ticket/core/domain/performance/model/Performance.java
+++ b/core/core-domain/src/main/java/com/ticket/core/domain/performance/model/Performance.java
@@ -100,32 +100,6 @@ public class Performance extends BaseEntity {
     public void updateQueuePolicy(
             final QueueMode queueMode,
             final QueueLevel queueLevel,
-            final Integer maxActiveUsers,
-            final Integer entryTokenTtlSeconds,
-            final LocalDateTime preopenQueueStartAt,
-            final String waitingRoomMessage,
-            final String reason
-    ) {
-        updateQueuePolicy(
-                queueMode,
-                queueLevel,
-                maxActiveUsers,
-                null,
-                entryTokenTtlSeconds,
-                null,
-                preopenQueueStartAt,
-                waitingRoomMessage,
-                reason
-        );
-    }
-
-    public void updateQueuePolicy(
-            final QueueMode queueMode,
-            final QueueLevel queueLevel,
-            final Integer maxActiveUsers,
-            final Integer admitLimitPerTick,
-            final Integer entryTokenTtlSeconds,
-            final Integer sessionTtlSeconds,
             final LocalDateTime preopenQueueStartAt,
             final String waitingRoomMessage,
             final String reason
@@ -135,10 +109,6 @@ public class Performance extends BaseEntity {
                     this,
                     queueMode,
                     queueLevel,
-                    maxActiveUsers,
-                    admitLimitPerTick,
-                    entryTokenTtlSeconds,
-                    sessionTtlSeconds,
                     preopenQueueStartAt,
                     waitingRoomMessage,
                     reason
@@ -148,10 +118,6 @@ public class Performance extends BaseEntity {
         queuePolicy.update(
                 queueMode,
                 queueLevel,
-                maxActiveUsers,
-                admitLimitPerTick,
-                entryTokenTtlSeconds,
-                sessionTtlSeconds,
                 preopenQueueStartAt,
                 waitingRoomMessage,
                 reason
@@ -164,14 +130,6 @@ public class Performance extends BaseEntity {
 
     public QueueLevel getQueueLevel() {
         return queuePolicy == null ? null : queuePolicy.getQueueLevel();
-    }
-
-    public Integer getMaxActiveUsers() {
-        return queuePolicy == null ? null : queuePolicy.getMaxActiveUsers();
-    }
-
-    public Integer getEntryTokenTtlSeconds() {
-        return queuePolicy == null ? null : queuePolicy.getEntryTokenTtlSeconds();
     }
 
     public LocalDateTime getPreopenQueueStartAt() {

--- a/core/core-domain/src/main/java/com/ticket/core/domain/performance/model/PerformanceQueuePolicy.java
+++ b/core/core-domain/src/main/java/com/ticket/core/domain/performance/model/PerformanceQueuePolicy.java
@@ -42,18 +42,6 @@ public class PerformanceQueuePolicy extends BaseEntity {
     private QueueLevel queueLevel;
 
     @Column
-    private Integer maxActiveUsers;
-
-    @Column
-    private Integer admitLimitPerTick;
-
-    @Column
-    private Integer entryTokenTtlSeconds;
-
-    @Column
-    private Integer sessionTtlSeconds;
-
-    @Column
     private LocalDateTime preopenQueueStartAt;
 
     @Column(length = 255)
@@ -66,10 +54,6 @@ public class PerformanceQueuePolicy extends BaseEntity {
             final Performance performance,
             final QueueMode queueMode,
             final QueueLevel queueLevel,
-            final Integer maxActiveUsers,
-            final Integer admitLimitPerTick,
-            final Integer entryTokenTtlSeconds,
-            final Integer sessionTtlSeconds,
             final LocalDateTime preopenQueueStartAt,
             final String waitingRoomMessage,
             final String reason
@@ -81,10 +65,6 @@ public class PerformanceQueuePolicy extends BaseEntity {
         update(
                 queueMode,
                 queueLevel,
-                maxActiveUsers,
-                admitLimitPerTick,
-                entryTokenTtlSeconds,
-                sessionTtlSeconds,
                 preopenQueueStartAt,
                 waitingRoomMessage,
                 reason
@@ -95,10 +75,6 @@ public class PerformanceQueuePolicy extends BaseEntity {
             final Performance performance,
             final QueueMode queueMode,
             final QueueLevel queueLevel,
-            final Integer maxActiveUsers,
-            final Integer admitLimitPerTick,
-            final Integer entryTokenTtlSeconds,
-            final Integer sessionTtlSeconds,
             final LocalDateTime preopenQueueStartAt,
             final String waitingRoomMessage,
             final String reason
@@ -107,10 +83,6 @@ public class PerformanceQueuePolicy extends BaseEntity {
                 performance,
                 queueMode,
                 queueLevel,
-                maxActiveUsers,
-                admitLimitPerTick,
-                entryTokenTtlSeconds,
-                sessionTtlSeconds,
                 preopenQueueStartAt,
                 waitingRoomMessage,
                 reason
@@ -120,20 +92,12 @@ public class PerformanceQueuePolicy extends BaseEntity {
     public void update(
             final QueueMode queueMode,
             final QueueLevel queueLevel,
-            final Integer maxActiveUsers,
-            final Integer admitLimitPerTick,
-            final Integer entryTokenTtlSeconds,
-            final Integer sessionTtlSeconds,
             final LocalDateTime preopenQueueStartAt,
             final String waitingRoomMessage,
             final String reason
     ) {
         this.queueMode = queueMode;
         this.queueLevel = queueLevel;
-        this.maxActiveUsers = maxActiveUsers;
-        this.admitLimitPerTick = admitLimitPerTick;
-        this.entryTokenTtlSeconds = entryTokenTtlSeconds;
-        this.sessionTtlSeconds = sessionTtlSeconds;
         this.preopenQueueStartAt = preopenQueueStartAt;
         this.waitingRoomMessage = waitingRoomMessage;
         this.reason = reason;

--- a/core/core-domain/src/main/java/com/ticket/core/domain/performanceseat/command/SelectSeatUseCase.java
+++ b/core/core-domain/src/main/java/com/ticket/core/domain/performanceseat/command/SelectSeatUseCase.java
@@ -1,5 +1,6 @@
 package com.ticket.core.domain.performanceseat.command;
 
+import com.ticket.core.domain.performance.query.PerformanceFinder;
 import com.ticket.core.domain.performanceseat.support.SeatStatusEventPublisher;
 import com.ticket.core.support.lock.DistributedLock;
 import com.ticket.core.domain.performanceseat.support.SeatSelectionAvailabilityValidator;
@@ -7,13 +8,18 @@ import com.ticket.core.domain.performanceseat.support.SeatStatusMessage.SeatActi
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class SelectSeatUseCase {
 
+    private final PerformanceFinder performanceFinder;
     private final SeatSelectionService seatSelectionService;
     private final SeatSelectionAvailabilityValidator seatSelectionAvailabilityValidator;
     private final SeatStatusEventPublisher seatEventPublisher;
+    private final Clock clock;
 
     public record Input(Long performanceId, Long seatId, Long memberId) {}
 
@@ -22,6 +28,7 @@ public class SelectSeatUseCase {
             dynamicKey = "#input.performanceId() + ':' + #input.seatId()"
     )
     public void execute(final Input input) {
+        performanceFinder.findValidPerformanceById(input.performanceId(), LocalDateTime.now(clock));
         seatSelectionAvailabilityValidator.validate(input.performanceId(), input.seatId());
         seatSelectionService.select(input.performanceId(), input.seatId(), input.memberId());
         seatEventPublisher.publish(input.performanceId(), input.seatId(), SeatAction.SELECTED);

--- a/core/core-domain/src/main/java/com/ticket/core/domain/performanceseat/query/GetSeatStatusUseCase.java
+++ b/core/core-domain/src/main/java/com/ticket/core/domain/performanceseat/query/GetSeatStatusUseCase.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -23,6 +25,7 @@ public class GetSeatStatusUseCase {
     private final SeatMapQueryRepository seatMapQueryRepository;
     private final SeatSelectionService seatSelectionService;
     private final HoldManager holdManager;
+    private final Clock clock;
 
     public record Input(Long performanceId) {}
 
@@ -31,7 +34,10 @@ public class GetSeatStatusUseCase {
     ) {}
 
     public Output execute(Input input) {
-        final Performance performance = performanceFinder.findById(input.performanceId());
+        final Performance performance = performanceFinder.findValidPerformanceById(
+                input.performanceId(),
+                LocalDateTime.now(clock)
+        );
         final Long perfId = performance.getId();
 
         final List<SeatStateView> dbStates = seatMapQueryRepository.findSeatStatuses(perfId);

--- a/core/core-domain/src/test/java/com/ticket/core/domain/performance/model/PerformanceQueuePolicyTest.java
+++ b/core/core-domain/src/test/java/com/ticket/core/domain/performance/model/PerformanceQueuePolicyTest.java
@@ -12,7 +12,7 @@ class PerformanceQueuePolicyTest {
     @Test
     void force_on_requires_queue() {
         Performance performance = performance();
-        performance.updateQueuePolicy(QueueMode.FORCE_ON, QueueLevel.LEVEL_1, 300, 300, null, null, null);
+        performance.updateQueuePolicy(QueueMode.FORCE_ON, QueueLevel.LEVEL_1, null, null, null);
 
         assertThat(performance.requiresQueueAt(LocalDateTime.of(2026, 5, 24, 19, 0))).isTrue();
     }
@@ -23,7 +23,7 @@ class PerformanceQueuePolicyTest {
         assertThat(emptyPolicy.requiresQueueAt(LocalDateTime.of(2026, 5, 24, 19, 0))).isFalse();
 
         Performance forceOff = performance();
-        forceOff.updateQueuePolicy(QueueMode.FORCE_OFF, QueueLevel.LEVEL_1, 300, 300, null, null, null);
+        forceOff.updateQueuePolicy(QueueMode.FORCE_OFF, QueueLevel.LEVEL_1, null, null, null);
         assertThat(forceOff.requiresQueueAt(LocalDateTime.of(2026, 5, 24, 19, 0))).isFalse();
     }
 
@@ -35,8 +35,6 @@ class PerformanceQueuePolicyTest {
         performance.updateQueuePolicy(
                 QueueMode.AUTO,
                 QueueLevel.LEVEL_1,
-                300,
-                300,
                 LocalDateTime.of(2026, 5, 24, 19, 50),
                 null,
                 null

--- a/core/core-domain/src/test/java/com/ticket/core/domain/performance/model/PerformanceTest.java
+++ b/core/core-domain/src/test/java/com/ticket/core/domain/performance/model/PerformanceTest.java
@@ -143,8 +143,6 @@ class PerformanceTest {
         performance.updateQueuePolicy(
                 QueueMode.FORCE_ON,
                 QueueLevel.LEVEL_2,
-                500,
-                900,
                 preopen,
                 "대기열 운영",
                 "초기 정책"
@@ -153,8 +151,6 @@ class PerformanceTest {
         // then
         assertThat(performance.getQueueMode()).isEqualTo(QueueMode.FORCE_ON);
         assertThat(performance.getQueueLevel()).isEqualTo(QueueLevel.LEVEL_2);
-        assertThat(performance.getMaxActiveUsers()).isEqualTo(500);
-        assertThat(performance.getEntryTokenTtlSeconds()).isEqualTo(900);
         assertThat(performance.getPreopenQueueStartAt()).isEqualTo(preopen);
         assertThat(performance.getWaitingRoomMessage()).isEqualTo("대기열 운영");
         assertThat(performance.getReason()).isEqualTo("초기 정책");

--- a/core/core-domain/src/test/java/com/ticket/core/domain/performance/query/BookingEntryResolverTest.java
+++ b/core/core-domain/src/test/java/com/ticket/core/domain/performance/query/BookingEntryResolverTest.java
@@ -49,7 +49,7 @@ class BookingEntryResolverTest {
                 4,
                 300
         );
-        performance.updateQueuePolicy(queueMode, QueueLevel.LEVEL_1, 300, 300, null, null, null);
+        performance.updateQueuePolicy(queueMode, QueueLevel.LEVEL_1, null, null, null);
         return performance;
     }
 }

--- a/core/core-domain/src/test/java/com/ticket/core/domain/performanceseat/command/SelectSeatUseCaseTest.java
+++ b/core/core-domain/src/test/java/com/ticket/core/domain/performanceseat/command/SelectSeatUseCaseTest.java
@@ -1,20 +1,40 @@
 package com.ticket.core.domain.performanceseat.command;
 
+import com.ticket.core.domain.performance.query.PerformanceFinder;
 import com.ticket.core.domain.performanceseat.support.SeatStatusEventPublisher;
 import com.ticket.core.domain.performanceseat.support.SeatSelectionAvailabilityValidator;
 import com.ticket.core.domain.performanceseat.support.SeatStatusMessage.SeatAction;
+import com.ticket.core.support.exception.CoreException;
+import com.ticket.core.support.exception.ErrorType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
 class SelectSeatUseCaseTest {
+
+    private static final Clock CLOCK = Clock.fixed(
+            Instant.parse("2026-08-04T01:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+    private static final LocalDateTime NOW = LocalDateTime.now(CLOCK);
+
+    @Mock
+    private PerformanceFinder performanceFinder;
 
     @Mock
     private SeatSelectionService seatSelectionService;
@@ -25,8 +45,18 @@ class SelectSeatUseCaseTest {
     @Mock
     private SeatStatusEventPublisher seatEventPublisher;
 
-    @InjectMocks
     private SelectSeatUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new SelectSeatUseCase(
+                performanceFinder,
+                seatSelectionService,
+                seatSelectionAvailabilityValidator,
+                seatEventPublisher,
+                CLOCK
+        );
+    }
 
     @Test
     void select_then_publish_selected_event() {
@@ -34,9 +64,27 @@ class SelectSeatUseCaseTest {
 
         useCase.execute(input);
 
-        InOrder inOrder = inOrder(seatSelectionAvailabilityValidator, seatSelectionService, seatEventPublisher);
+        InOrder inOrder = inOrder(
+                performanceFinder,
+                seatSelectionAvailabilityValidator,
+                seatSelectionService,
+                seatEventPublisher
+        );
+        inOrder.verify(performanceFinder).findValidPerformanceById(10L, NOW);
         inOrder.verify(seatSelectionAvailabilityValidator).validate(10L, 20L);
         inOrder.verify(seatSelectionService).select(10L, 20L, 1L);
         inOrder.verify(seatEventPublisher).publish(10L, 20L, SeatAction.SELECTED);
+    }
+
+    @Test
+    void 예매가_마감된_회차는_좌석을_선택하지_않는다() {
+        SelectSeatUseCase.Input input = new SelectSeatUseCase.Input(10L, 20L, 1L);
+        when(performanceFinder.findValidPerformanceById(10L, NOW))
+                .thenThrow(new CoreException(ErrorType.PERFORMANCE_IS_PAST));
+
+        assertThatThrownBy(() -> useCase.execute(input))
+                .isInstanceOf(CoreException.class);
+
+        verifyNoInteractions(seatSelectionAvailabilityValidator, seatSelectionService, seatEventPublisher);
     }
 }

--- a/core/core-domain/src/test/java/com/ticket/core/domain/performanceseat/query/GetSeatStatusUseCaseTest.java
+++ b/core/core-domain/src/test/java/com/ticket/core/domain/performanceseat/query/GetSeatStatusUseCaseTest.java
@@ -6,23 +6,37 @@ import com.ticket.core.domain.performance.query.PerformanceFinder;
 import com.ticket.core.domain.performanceseat.command.SeatSelectionService;
 import com.ticket.core.domain.performanceseat.query.model.SeatStateView;
 import com.ticket.core.domain.performanceseat.query.model.SeatStatus;
+import com.ticket.core.support.exception.CoreException;
+import com.ticket.core.support.exception.ErrorType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
 class GetSeatStatusUseCaseTest {
+
+    private static final Clock CLOCK = Clock.fixed(
+            Instant.parse("2026-08-04T01:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+    private static final LocalDateTime NOW = LocalDateTime.now(CLOCK);
 
     @Mock
     private PerformanceFinder performanceFinder;
@@ -33,13 +47,23 @@ class GetSeatStatusUseCaseTest {
     @Mock
     private HoldManager holdManager;
 
-    @InjectMocks
     private GetSeatStatusUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetSeatStatusUseCase(
+                performanceFinder,
+                seatMapQueryRepository,
+                seatSelectionService,
+                holdManager,
+                CLOCK
+        );
+    }
 
     @Test
     void redis가_점유중인_available_좌석은_occupied로_변환한다() {
         Performance performance = mock(Performance.class);
-        when(performanceFinder.findById(10L)).thenReturn(performance);
+        when(performanceFinder.findValidPerformanceById(10L, NOW)).thenReturn(performance);
         when(performance.getId()).thenReturn(10L);
         when(seatMapQueryRepository.findSeatStatuses(10L)).thenReturn(List.of(
                 new SeatStateView(1L, SeatStatus.AVAILABLE),
@@ -63,7 +87,7 @@ class GetSeatStatusUseCaseTest {
                 new SeatStateView(1L, SeatStatus.AVAILABLE),
                 new SeatStateView(2L, SeatStatus.OCCUPIED)
         );
-        when(performanceFinder.findById(10L)).thenReturn(performance);
+        when(performanceFinder.findValidPerformanceById(10L, NOW)).thenReturn(performance);
         when(performance.getId()).thenReturn(10L);
         when(seatMapQueryRepository.findSeatStatuses(10L)).thenReturn(dbStates);
         when(seatSelectionService.getSelectingSeatIds(10L)).thenReturn(Set.of());
@@ -73,5 +97,16 @@ class GetSeatStatusUseCaseTest {
 
         assertThat(output.seats()).containsExactlyElementsOf(dbStates);
         verify(seatMapQueryRepository).findSeatStatuses(10L);
+    }
+
+    @Test
+    void 예매가_마감된_회차는_좌석_상태를_조회하지_않는다() {
+        when(performanceFinder.findValidPerformanceById(10L, NOW))
+                .thenThrow(new CoreException(ErrorType.PERFORMANCE_IS_PAST));
+
+        assertThatThrownBy(() -> useCase.execute(new GetSeatStatusUseCase.Input(10L)))
+                .isInstanceOf(CoreException.class);
+
+        verifyNoInteractions(seatMapQueryRepository, seatSelectionService, holdManager);
     }
 }

--- a/core/core-domain/src/test/java/com/ticket/core/domain/show/query/ShowDetailQueryRepositoryTest.java
+++ b/core/core-domain/src/test/java/com/ticket/core/domain/show/query/ShowDetailQueryRepositoryTest.java
@@ -60,9 +60,9 @@ class ShowDetailQueryRepositoryTest extends QueryRepositoryTestSupport {
         persistShowGrade(show, "VIP", "VIP석", BigDecimal.valueOf(150000), 1);
         persistShowGrade(show, "R", "R석", BigDecimal.valueOf(100000), 2);
         Performance queuedPerformance = persistPerformance(show, 1L, LocalDate.of(2026, 3, 16).atTime(14, 0));
-        queuedPerformance.updateQueuePolicy(QueueMode.FORCE_ON, QueueLevel.LEVEL_1, null, null, null, null, null);
+        queuedPerformance.updateQueuePolicy(QueueMode.FORCE_ON, QueueLevel.LEVEL_1, null, null, null);
         Performance directPerformance = persistPerformance(show, 2L, LocalDate.of(2026, 3, 16).atTime(19, 0));
-        directPerformance.updateQueuePolicy(QueueMode.FORCE_OFF, QueueLevel.LEVEL_1, null, null, null, null, null);
+        directPerformance.updateQueuePolicy(QueueMode.FORCE_OFF, QueueLevel.LEVEL_1, null, null, null);
         persistShowLike(persistMember("a@example.com", "A"), show);
         persistShowLike(persistMember("b@example.com", "B"), show);
         flushAndClear();


### PR DESCRIPTION
## 변경 목적

- 공연별 대기열 정책에서 Queue가 더 이상 사용하지 않는 처리량·TTL 설정을 제거합니다.
- 예매가 마감된 공연에서는 좌석 선택과 좌석 상태 조회가 진행되지 않도록 공연 유효성 검증을 보강합니다.

## 주요 변경 내용

- `PerformanceQueuePolicy`를 `queueMode`, `queueLevel`, `preopenQueueStartAt`, 안내 문구, 운영 사유 중심으로 단순화했습니다.
- `maxActiveUsers`, `admitLimitPerTick`, `entryTokenTtlSeconds`, `sessionTtlSeconds` 매핑과 API를 제거했습니다.
- 좌석 선택·상태 조회 전에 `PerformanceFinder.findValidPerformanceById(..., now)`를 호출하도록 변경했습니다.
- 고정 `Clock`을 사용해 예매 마감 회차의 좌석 접근 차단을 테스트했습니다.

## 리뷰 포인트

- 기존 DB의 nullable 정책 컬럼은 이번 PR에서 삭제하지 않습니다. 코드에서 먼저 사용을 중단하고, 필요 시 별도 마이그레이션으로 정리합니다.
- 공연 유효성 검증이 좌석 조회·선택·이벤트 발행보다 먼저 수행되는지 확인해 주세요.

## 영향 범위

- [x] `core/core-api` 진입점 또는 응답 형식 변경
- [x] `core/core-domain` 비즈니스 규칙 변경
- [ ] Redis key, TTL, expiration listener 변경
- [ ] 분산 락 또는 동시성 제어 변경
- [ ] DB 스키마 또는 쿼리 영향 있음
- [ ] 보안, 인증, 권한 처리 영향 있음

## 테스트

- [x] `./gradlew :core:core-api:compileJava`
- [x] `./gradlew :core:core-domain:test`
- [x] `./gradlew :core:core-api:test`

### 테스트 결과

- Core domain 테스트 성공
- Core API 테스트 성공
- `git diff --check` 성공

## 배포 및 롤백

- DB 마이그레이션은 없습니다.
- 문제 발생 시 두 커밋을 순서대로 revert할 수 있습니다.

## 체크리스트

- [x] 요청 범위를 벗어난 변경이 없습니다.
- [x] 불필요한 추상화나 리팩터링을 추가하지 않았습니다.
- [x] 회귀 가능성이 있는 지점과 테스트 공백을 확인했습니다.
- [x] 문서 또는 리뷰 설명은 한국어로 작성했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 대기열 정책 설정에서 불필요한 세부 설정 항목을 제거해 구성을 간소화했습니다.
  * 좌석 선택 및 좌석 상태 조회 시 유효한 공연 회차만 처리하도록 개선했습니다.
  * 종료된 공연에 대한 좌석 접근을 제한하고, 관련 처리를 수행하지 않도록 했습니다.

* **테스트**
  * 공연 유효성 및 종료 상태에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->