### PR TITLE
ci(deploy): 문서 변경에 운영 배포가 걸리지 않게 경로 필터 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,21 @@ name: Backend CI/CD (Docker Hub)
 on:
   push:
     branches: [ "master" ]
+    # 배포 산출물에 들어가지 않는 파일만 무시한다. Dockerfile은 jar만 COPY하므로
+    # 문서와 에이전트·리뷰 설정 변경은 이미지 내용을 바꾸지 않는다.
+    # 무시 대상만 담긴 push는 workflow가 아예 실행되지 않으므로 운영 재시작도 일어나지 않는다.
+    # 필요하면 workflow_dispatch로 언제든 수동 배포할 수 있다.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.claude/**'
+      - '.codex/**'
+      - '.codescene/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.coderabbit.yaml'
+      - '.pr_agent.toml'
+      - '.gitignore'
+      - '.gitattributes'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## 변경 목적

`deploy.yml`에 경로 필터가 없어 **문서만 바꾼 `master` push에도 운영 배포가 전부 실행됩니다.** 이미지 재빌드, SSH 배포, `docker restart ticket-nginx`까지 돌아 산출물이 동일한데도 운영 서비스가 재시작됩니다. 배포 산출물에 영향을 주지 않는 경로만 `paths-ignore`로 제외합니다.

## 주요 변경 내용

`.github/workflows/deploy.yml`의 `push` 트리거에 `paths-ignore`를 추가했습니다. 15줄 추가, 삭제 없음.

```yaml
on:
  push:
    branches: [ "master" ]
    paths-ignore:
      - '**/*.md'
      - 'docs/**'
      - '.claude/**'
      - '.codex/**'
      - '.codescene/**'
      - '.github/ISSUE_TEMPLATE/**'
      - '.coderabbit.yaml'
      - '.pr_agent.toml'
      - '.gitignore'
      - '.gitattributes'
  workflow_dispatch:
```

**제외 대상을 이렇게 고른 근거**

- `Dockerfile`은 `COPY core/core-api/build/libs/*.jar app.jar` 하나뿐입니다. 이미지에 들어가는 것은 jar와 Datadog agent이며 문서는 포함되지 않습니다.
- 각 모듈의 `src/main/resources`에 `.md` 파일이 없음을 확인했습니다. 마크다운은 빌드 입력이 아닙니다.
- `docs/`에는 `database/core-api-query-indexes.sql`처럼 `.md`가 아닌 파일도 있지만, 배포 전 점검용 SQL이라 이미지와 무관합니다.

**의도적으로 제외하지 않은 것**

- **`.github/workflows/**`** — 배포 절차 자체를 고쳤을 때는 배포가 트리거돼야 합니다. 이걸 무시하면 `deploy.yml`을 수정해도 반영을 확인할 수 없습니다.
- **`ci.yml`은 손대지 않았습니다.** PR 검증은 문서 변경에도 항상 실행돼야 합니다.

## 리뷰 포인트

- 제외 목록에 배포에 영향을 주는 경로가 섞여 있지 않은지 봐 주세요. 판단 기준은 "이미지 내용이나 배포 절차를 바꾸는가"입니다.
- `**/*.md`가 너무 넓다고 보시면 `docs/**`, `*.md`(루트만), `README.md`로 좁힐 수 있습니다.
- 무시 대상만 담긴 push는 workflow가 **실행 자체를 하지 않습니다**(skipped도 아님). `deploy.yml`은 PR 필수 체크가 아니므로 머지 흐름에는 영향이 없습니다.
- 급하게 재배포가 필요하면 `workflow_dispatch`로 언제든 수동 실행할 수 있습니다.

## 영향 범위

- [ ] `core/core-api` 진입점 또는 응답 형식 변경
- [ ] `core/core-domain` 비즈니스 규칙 변경
- [ ] Redis key, TTL, expiration listener 변경
- [ ] 분산 락 또는 동시성 제어 변경
- [ ] DB 스키마 또는 쿼리 영향 있음
- [ ] 보안, 인증, 권한 처리 영향 있음

해당 없음 — CI/CD 트리거 조건만 변경했습니다.

## 테스트

- [ ] `./gradlew :core:core-api:compileJava`
- [ ] `./gradlew :core:core-domain:test`
- [ ] 로컬 실행 또는 수동 검증 수행

### 테스트 결과

Java 파일 변경이 없어 워크플로 자체를 검증했습니다.

- `yaml.safe_load`로 파싱 성공, `on` 키가 `push`·`workflow_dispatch` 그대로, `jobs`가 `verify`·`build-and-deploy` 그대로임을 확인했습니다.
- 변경 파일은 `.github/workflows/deploy.yml` 하나이며 기존 줄 삭제 없이 15줄만 추가했습니다.
- 이 저장소의 테스트 중 `.github/workflows/deploy.yml`을 읽는 것이 없음을 확인했습니다(형제 저장소 `ticket-queue`에는 있어 그쪽 PR에서는 해당 테스트를 실행했습니다).

동작 자체는 머지 후 첫 문서 변경 push에서 확인됩니다. 그때 `deploy.yml`이 실행되지 않아야 정상입니다.

## 배포 및 롤백

- 이 PR 자체의 머지는 `.github/workflows/`를 바꾸므로 **정상적으로 배포가 트리거됩니다.** 필터는 그 다음 push부터 적용됩니다.
- 롤백은 이 커밋 하나를 revert하면 즉시 원래 동작(모든 `master` push에 배포)으로 돌아갑니다.

## 체크리스트

- [x] PR 제목이 `<type>(<scope>): <한국어 설명>` 형식을 따릅니다.
- [x] 요청 범위를 벗어난 변경이 없습니다.
- [x] 불필요한 추상화나 리팩터링을 추가하지 않았습니다.
- [x] 회귀 가능성이 있는 지점과 테스트 공백을 확인했습니다.
- [x] 문서 또는 리뷰 설명은 한국어로 작성했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
